### PR TITLE
Update to react-select 5.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3845,18 +3845,6 @@
         "redux": "^4.0.0"
       }
     },
-    "@types/react-select": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@types/react-select/-/react-select-4.0.17.tgz",
-      "integrity": "sha512-ZK5wcBhJaqC8ntQl0CJvK2KXNNsk1k5flM7jO+vNPPlceRzdJQazA6zTtQUyNr6exp5yrAiwiudtYxgGlgGHLg==",
-      "dev": true,
-      "requires": {
-        "@emotion/serialize": "^1.0.0",
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "@types/react-transition-group": "*"
-      }
-    },
     "@types/react-transition-group": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.1.tgz",
@@ -5163,15 +5151,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "optional": true
-    },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "optional": true,
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
     },
     "bluebird": {
       "version": "3.7.2",
@@ -8124,12 +8103,6 @@
           }
         }
       }
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "optional": true
     },
     "filesize": {
       "version": "6.1.0",
@@ -12006,12 +11979,6 @@
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
     },
-    "nan": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-      "optional": true
-    },
     "nano-css": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/nano-css/-/nano-css-5.3.4.tgz",
@@ -14385,14 +14352,6 @@
         }
       }
     },
-    "react-input-autosize": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-3.0.0.tgz",
-      "integrity": "sha512-nL9uS7jEs/zu8sqwFE5MAPx6pPkNAriACQ2rGLlqmKr2sPGtN7TXTyDdQt4lbNXVx7Uzadb40x8qotIuru6Rhg==",
-      "requires": {
-        "prop-types": "^15.5.8"
-      }
-    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -14495,31 +14454,17 @@
       }
     },
     "react-select": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-4.3.1.tgz",
-      "integrity": "sha512-HBBd0dYwkF5aZk1zP81Wx5UsLIIT2lSvAY2JiJo199LjoLHoivjn9//KsmvQMEFGNhe58xyuOITjfxKCcGc62Q==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.1.0.tgz",
+      "integrity": "sha512-SkEBD1AYsSXrIdNj5HBt7+Ehe+jxdiB448J0atJqR6lE3l/GcFlRf4JYB3NlHe/02jrW4AnIQLo1t0IqWrxXOw==",
       "requires": {
         "@babel/runtime": "^7.12.0",
         "@emotion/cache": "^11.4.0",
         "@emotion/react": "^11.1.1",
+        "@types/react-transition-group": "^4.4.0",
         "memoize-one": "^5.0.0",
         "prop-types": "^15.6.0",
-        "react-input-autosize": "^3.0.0",
         "react-transition-group": "^4.3.0"
-      },
-      "dependencies": {
-        "@emotion/cache": {
-          "version": "11.4.0",
-          "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.4.0.tgz",
-          "integrity": "sha512-Zx70bjE7LErRO9OaZrhf22Qye1y4F7iDl+ITjet0J+i+B88PrAOBkKvaAWhxsZf72tDLajwCgfCjJ2dvH77C3g==",
-          "requires": {
-            "@emotion/memoize": "^0.7.4",
-            "@emotion/sheet": "^1.0.0",
-            "@emotion/utils": "^1.0.0",
-            "@emotion/weak-memoize": "^0.2.5",
-            "stylis": "^4.0.3"
-          }
-        }
       }
     },
     "react-transition-group": {
@@ -17432,11 +17377,7 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1"
-          }
+          "optional": true
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -18035,11 +17976,7 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1"
-          }
+          "optional": true
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react-player": "^2.9.0",
     "react-redux": "^7.2.5",
     "react-scripts": "4.0.3",
-    "react-select": "^4.3.1",
+    "react-select": "^5.1.0",
     "react-use": "^17.3.1",
     "redux": "^4.1.0",
     "standardized-audio-context": "^25.3.12",
@@ -84,7 +84,6 @@
     "@types/lodash": "^4.14.175",
     "@types/luxon": "^2.0.2",
     "@types/react-beforeunload": "^2.1.1",
-    "@types/react-select": "^4.0.17",
     "redux-devtools": "^3.7.0",
     "use-resize-observer": "^8.0.0"
   }


### PR DESCRIPTION
This patch updates `react-select`, removing `@types/react-select` since it is no longer required.

This closes #460