### PR TITLE
Include Build Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
     "web-vitals": "^2.1.0"
   },
   "scripts": {
-    "start": "react-app-rewired start",
-    "build": "react-app-rewired build",
+    "start": "REACT_APP_GIT_SHA=`git rev-parse HEAD` REACT_APP_BUILD_DATE=\"`date`\" react-app-rewired start",
+    "build": "REACT_APP_GIT_SHA=`git rev-parse HEAD` REACT_APP_BUILD_DATE=\"`date`\" react-app-rewired build",
     "test": "react-app-rewired test",
     "eject": "react-app-rewired eject",
     "test:debug": "react-scripts --inspect-brk test --runInBand --no-cache"

--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta name="git-commit" content="%REACT_APP_GIT_SHA%">
+    <meta name="build-date" content="%REACT_APP_BUILD_DATE%">
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
This patch automatically adds the build version (git commit hash) and
build date to the release so that it is easier for developers and admins
to find out which version is actually deployed. It is only an HTML meta
field and thus completely invisible to non-technical users.

```html
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta name="git-commit" content="3234bb106a4d8ec0cbbb9ff8ffd192625a7a2aa0">
    <meta name="build-date" content="Tue Oct 12 07:39:52 PM CEST 2021">
    <meta …
```

This fixes #463