### PR TITLE
Automatically Update Translations

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -1,0 +1,38 @@
+name: Update translations
+
+on:
+  schedule:
+  - cron: "0 5 * * 1"
+
+jobs:
+  update-translations:
+    if: github.repository_owner == 'opencast'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: prepare git
+        run: |
+          git config --global user.email 'crowdin-bot@editor.opencast.org'
+          git config --global user.name 'Crowdin Bot'
+
+      - name: prepare crowdin client
+        run: |
+          wget --quiet https://artifacts.crowdin.com/repo/deb/crowdin3.deb -O crowdin.deb
+          sudo dpkg -i crowdin.deb
+
+      - name: download translations
+        env:
+          CROWDIN_TOKEN: ${{ secrets.CROWDIN_TOKEN }}
+        run: |
+          crowdin download --config .crowdin.yaml -b main
+
+      - name: add new translations
+        run: |
+          git add src/i18n/locales
+
+      - name: upload translations
+        run: |
+          if git commit -m "Automatically update translation keys"; then
+            git push
+          fi

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1,0 +1,183 @@
+{
+    "mainMenu": {
+        "cutting-button": "Schneiden",
+        "finish-button": "Fertigstellen",
+        "select-tracks-button": "Spuren",
+        "thumbnail-button": "Vorschaubild",
+        "metadata-button": "Metadaten",
+        "tooltip-aria": "Hauptnavigation"
+    },
+    "cuttingActions": {
+        "cut-button": "Schneiden",
+        "cut-tooltip": "Teilen Sie das Segment an der aktuellen Position des Zeitmarkers. Hotkey: {{hotkeyName}}",
+        "cut-tooltip-aria": "Schnitt. Teilen Sie das Segment an der aktuellen Position des Zeitmarkers. Hotkey: {{hotkeyName}}.",
+        "delete-button": "Löschen",
+        "delete-restore-tooltip": "Markieren oder entfernen Sie das Segment an der aktuellen Position zur Löschung. Hotkey: {{hotkeyName}}",
+        "delete-restore-tooltip-aria": "Löschen und Wiederherstellen. Markieren oder entfernen Sie das Segment an der aktuellen Position zur Löschung. Hotkey: {{hotKeyName}}.",
+        "restore-button": "Wiederherstellen",
+        "mergeLeft-button": "Links zusammenfügen",
+        "mergeLeft-tooltip": "Kombiniere das aktuell aktive Segment mit dem Segment auf der linken Seite. Hotkey: {{hotkeyName}}",
+        "mergeLeft-tooltip-aria": "Links zusammenfügen. Kombinieren Sie das aktuell aktive Segment mit dem Segment auf der linken Seite. Hotkey: {{hotkeyName}}.",
+        "mergeRight-button": "Rechts zusammenfügen",
+        "mergeRight-tooltip": "Kombiniere das aktuell aktive Segment mit dem Segment auf der rechten Seite. Hotkey: {{hotkeyName}}",
+        "mergeRight-tooltip-aria": "Rechts zusammenfügen. Kombinieren Sie das aktuell aktive Segment mit dem Segment auf der rechten Seite. Hotkey: {{hotkeyName}}."
+    },
+    "video": {
+        "previewButton": "Vorschaumodus",
+        "previewButton-tooltip": "Überspringt gelöschte Segmente bei der Wiedergabe des Videos. Derzeit {{status}}. Hotkey: {{hotkeyName}}",
+        "previewButton-aria": "Vorschaumodus aktivieren oder deaktivieren. Hotkey: {{hotkeyName}}.",
+        "playButton-tooltip": "Wiedergabe-Button",
+        "time-duration-tooltip": "Wiedergabezeit und -dauer",
+        "duration-aria": "Dauer",
+        "time-aria": "Aktuelle Zeit",
+        "comError-text": "Bei der Kommunikation mit Opencast ist ein Problem aufgetreten.",
+        "loadError-text": "Beim Laden des Videos ist ein Fehler aufgetreten.",
+        "title-tooltip": "Videotitel",
+        "presenter-tooltip": "Vortragende",
+        "controls-tooltip": "Videosteuerungen"
+    },
+    "finishMenu": {
+        "save-button": "Änderungen speichern",
+        "start-button": "Verarbeitung starten",
+        "discard-button": "Änderungen verwerfen"
+    },
+    "save": {
+        "headline-text": "Aktuelles Projekt speichern",
+        "confirm-button": "Ja, Änderungen speichern",
+        "confirmButton-default-tooltip": "Speichern-Button",
+        "confirmButton-attempting-tooltip": "Versuche zu speichern",
+        "confirmButton-success-tooltip": "Erfolgreich gespeichert",
+        "confirmButton-failed-tooltip": "Speichern fehlgeschlagen",
+        "info-text": "Das Video wird nicht verarbeitet, aber alle Schnittinformationen werden in Opencast gespeichert. Sie können Ihre Bearbeitung später fortsetzen.",
+        "success-text": "Änderungen erfolgreich gespeichert!",
+        "success-tooltip-aria": "Erfolgreich gespeichert",
+        "saveArea-tooltip": "Speicherbereich"
+    },
+    "discard": {
+        "headline-text": "Änderungen verwerfen",
+        "confirm-button": "Ja, meine Änderungen verwerfen",
+        "confirm-tooltip": "Änderungen verwerfen Button",
+        "info-text": "Wollen Sie alle Änderungen verwerfen? Dies kann nicht rückgängig gemacht werden!"
+    },
+    "theEnd": {
+        "discarded-text": "Alle Ihre Änderungen sind nun für immer verloren gegangen. Sie können nun den Editor schließen.",
+        "startOver-button": "Von neu beginnen!",
+        "startOver-tooltip": "Seite neu laden, um neu zu starten",
+        "info-text": "Änderungen erfolgreich in Opencast gespeichert. Die Verarbeitung Ihrer Änderungen kann bis zu {{duration}} Stunden dauern. Sie können nun den Editor schließen.\n"
+    },
+    "workflowSelection": {
+        "saveAndProcess-text": "Speichern & verarbeiten",
+        "selectWF-text": "Workflow wählen",
+        "noWorkflows-text": "Ein Problem ist aufgetreten, es gibt keine Workflows für die Verarbeitung Ihrer Änderungen mit.<3/> Bitte speichern Sie Ihre Änderungen und kontaktieren Sie einen Opencast Administrator.\n",
+        "oneWorkflow-text": "Das Video wird mit dem Workflow \"{{workflow}}\" geschnitten und verarbeitet. <3/> Dies wird einige Zeit dauern.\n",
+        "manyWorkflows-text": "Wählen Sie aus, welchen Workflow Opencast für die Verarbeitung verwenden soll.",
+        "startProcessing-button": "Verarbeitung starten",
+        "back-button": "Bring mich zurück",
+        "selectWF-button": "Klicken, um diesen Workflow auszuwählen",
+        "selectWF-button-aria": "Klicken, um den Workflow auszuwählen: {{stateName}}\n"
+    },
+    "timeline": {
+        "generateWaveform-text": "Waveform wird generiert",
+        "segment-tooltip": "Segment {{segment}}",
+        "scrubber-text-aria": "Zeitmarker. {{currentTime}}. Aktives Segment: {{segment}}. {{segmentStatus}}. Kontrollen: {{moveLeft}} und {{moveRight}}, um den Zeitmarker zu bewegen. {{increase}} und {{decrease}}, um das Verschiebungdelta zu erhöhen/verringern.\n",
+        "segments-text-aria": "Segment {{index}}. {{segmentStatus}}. Start: {{start}}. Ende: {{end}}.\n"
+    },
+    "workflowConfig": {
+        "headline-text": "Workflow Konfiguration",
+        "area-tooltip": "Workflow-Konfigurationsbereich",
+        "satisfied-text": "Sind Sie zufrieden mit Ihrer Konfiguration?",
+        "confirm-button": "Ja, Verarbeitung starten"
+    },
+    "metadata": {
+        "EVENTS-EVENTS-DETAILS-CATALOG-EPISODE": "Video Metadaten",
+        "submit-button": "Abschicken",
+        "submit-button-tooltip": "Bestätigen Sie Ihre Änderungen",
+        "reset-button": "Zurücksetzen",
+        "reset-button-tooltip": "Alle Änderungen rückgängig machen",
+        "submit-helpertext": "Machen Sie so viele Änderungen, wie Sie möchten, dann drücken Sie den {{buttonName}} Button.\nBeachten Sie, dass Sie noch die Verarbeitung starten müssen, damit Ihre Änderungen wirksam werden.",
+        "validation": {
+            "required": "Erforderlich",
+            "duration-format": "Format muss HH:MM:SS sein",
+            "datetime": "Ungültig"
+        },
+        "labels": {
+            "title": "Titel",
+            "subject": "Betreff",
+            "description": "Beschreibung",
+            "language": "Sprache",
+            "rightsHolder": "Rechte",
+            "license": "Lizenz",
+            "isPartOf": "Serie",
+            "creator": "Vortragende(r)",
+            "contributor": "Mitwirkende(r)",
+            "startDate": "Startdatum",
+            "duration": "Dauer",
+            "location": "Ort",
+            "source": "Quelle",
+            "created": "Erstellt am",
+            "publisher": "Herausgeber",
+            "identifier": "UID"
+        },
+        "language": {
+            "LANGUAGES-SLOVENIAN": "Slowenisch",
+            "LANGUAGES-PORTUGESE": "Portugiesisch",
+            "LANGUAGES-ROMANSH": "Rätoromanisch",
+            "LANGUAGES-ARABIC": "Arabisch",
+            "LANGUAGES-POLISH": "Polnisch",
+            "LANGUAGES-ITALIAN": "Italienisch",
+            "LANGUAGES-CHINESE": "Chinesisch",
+            "LANGUAGES-FINNISH": "Finnisch",
+            "LANGUAGES-DANISH": "Dänisch",
+            "LANGUAGES-UKRAINIAN": "Ukrainisch",
+            "LANGUAGES-FRENCH": "Französisch",
+            "LANGUAGES-SPANISH": "Spanisch",
+            "LANGUAGES-GERMAN_CH": "Schweizerdeutsch",
+            "LANGUAGES-NORWEGIAN": "Norwegisch",
+            "LANGUAGES-RUSSIAN": "Russisch",
+            "LANGUAGES-JAPANESE": "Japanisch",
+            "LANGUAGES-DUTCH": "Niederländisch",
+            "LANGUAGES-TURKISH": "Türkisch",
+            "LANGUAGES-HINDI": "Hindi",
+            "LANGUAGES-SWEDISH": "Schwedisch",
+            "LANGUAGES-ENGLISH": "Englisch",
+            "LANGUAGES-GERMAN": "Deutsch"
+        },
+        "license": {
+            "EVENTS-LICENSE-CC0": "CC0",
+            "EVENTS-LICENSE-CCBYND": "CC-BY-ND",
+            "EVENTS-LICENSE-CCBYNCND": "CC-BY-NC-ND",
+            "EVENTS-LICENSE-CCBYNCSA": "CC-BY-NC-SA",
+            "EVENTS-LICENSE-ALLRIGHTS": "Alle Rechte vorbehalten",
+            "EVENTS-LICENSE-CCBYSA": "CC-BY-SA",
+            "EVENTS-LICENSE-CCBYNC": "CC-BY-NC",
+            "EVENTS-LICENSE-CCBY": "CC-BY"
+        }
+    },
+    "error": {
+        "generic-message": "Ein kritischer Fehler ist aufgetreten!",
+        "details": "Details: "
+    },
+    "landing": {
+        "main-heading": "Willkommen im Video-Editor",
+        "contact-admin": "Falls Sie versucht haben, ein bestimmtes Video zu bearbeiten, aber diese Seite sehen, wenden Sie sich bitte an Ihren Administrator.",
+        "start-editing-1": "Um mit der Bearbeitung zu beginnen, geben Sie den Parameter an ",
+        "start-editing-2": " mit der Mediapaket ID des Videos, das Sie bearbeiten möchten.",
+        "link-to-documentation": "Weitere Informationen zur Konfiguration des Video-Editors finden Sie im Administrationshandbuch unter "
+    },
+    "various": {
+        "error-details-text": "Details: {{errorMessage}}\n",
+        "error-noDetails-text": "Keine Fehlerdetails verfügbar.",
+        "error-text": "Ein Fehler ist aufgetreten. Bitte versuchen Sie es später noch einmal.",
+        "goBack-button": "Nein, zurück"
+    },
+    "trackSelection": {
+        "description": "Wählen oder deaktivieren Sie die Spuren für die Verarbeitung und Veröffentlichung.",
+        "trackInactive": "inaktiv",
+        "deleteTrackText": "Spur löschen",
+        "restoreTrackText": "Spur wiederherstellen",
+        "cannotDeleteTrackText": "Spur kann nicht gelöscht werden",
+        "deleteTrackTooltip": "Diesen Track nicht verarbeiten und veröffentlichen.",
+        "restoreTrackTooltip": "Diesen Track verarbeiten und veröffentlichen.",
+        "cannotDeleteTrackTooltip": "Dieser Track kann nicht entfernt werden."
+    }
+}

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1,0 +1,183 @@
+{
+    "mainMenu": {
+        "cutting-button": "Dividir",
+        "finish-button": "Finalizar",
+        "select-tracks-button": "Pistas",
+        "thumbnail-button": "Miniatura",
+        "metadata-button": "Metadatos",
+        "tooltip-aria": "Navegación principal"
+    },
+    "cuttingActions": {
+        "cut-button": "Cortar",
+        "cut-tooltip": "Dividir el segmento en la posición actual del marcador. Acceso Rápido:: {{hotkeyName}}",
+        "cut-tooltip-aria": "Dividir el segmento en la posición actual del marcador. Acceso Rápido:: {{hotkeyName}}.",
+        "delete-button": "Borrar",
+        "delete-restore-tooltip": "Marcar o desmarcar el segmento en la posición actual para ser eliminado. Acceso Rápido: {{hotkeyName}}",
+        "delete-restore-tooltip-aria": "Marcar o desmarcar el segmento en la posición actual para ser eliminado. Acceso Rápido:: {{hotKeyName}}.",
+        "restore-button": "Restaurar",
+        "mergeLeft-button": "Fusionar a la izquierda",
+        "mergeLeft-tooltip": "Combina el segmento actualmente activo con el segmento a su izquierda. Acceso rápido: {{hotkeyName}}",
+        "mergeLeft-tooltip-aria": "Combina el segmento actualmente activo con el segmento a su izquierda. Acceso rápido: {{hotkeyName}}.",
+        "mergeRight-button": "Fusionar a la derecha",
+        "mergeRight-tooltip": "Combina el segmento actualmente activo con el segmento a su izquierda. Acceso rápido: {{hotkeyName}}",
+        "mergeRight-tooltip-aria": "Combina el segmento actualmente activo con el segmento a su izquierda. Acceso rápido: {{hotkeyName}}."
+    },
+    "video": {
+        "previewButton": "Vista previa",
+        "previewButton-tooltip": "Salta los segmentos eliminados al reproducir el video. Actualmente {{status}}. Acceso rápido: {{hotkeyName}}",
+        "previewButton-aria": "Activa o desactiva el modo de vista previa. Tecla de acceso: {{hotkeyName}}.",
+        "playButton-tooltip": "Reproducir",
+        "time-duration-tooltip": "Duración y tiempo de reproducción",
+        "duration-aria": "Duración",
+        "time-aria": "Tiempo actual",
+        "comError-text": "Se ha producido un error al establecer comunicación con Opencast.",
+        "loadError-text": "Ocurrió un error al cargar el video.",
+        "title-tooltip": "Título del vídeo",
+        "presenter-tooltip": "Presentadores",
+        "controls-tooltip": "Controles"
+    },
+    "finishMenu": {
+        "save-button": "Guardar cambios",
+        "start-button": "Iniciar proceso",
+        "discard-button": "Descartar cambios"
+    },
+    "save": {
+        "headline-text": "Guardar el proyecto actual",
+        "confirm-button": "Sí, guardar cambios",
+        "confirmButton-default-tooltip": "Guardar",
+        "confirmButton-attempting-tooltip": "Intentando guardar",
+        "confirmButton-success-tooltip": "Guardado con éxito",
+        "confirmButton-failed-tooltip": "Falla al guardar",
+        "info-text": "El vídeo no será procesado, pero toda la información de corte será almacenada en Opencast. Puede continuar su edición más tarde.",
+        "success-text": "¡Cambios guardados con éxito!",
+        "success-tooltip-aria": "Guardado con éxito",
+        "saveArea-tooltip": "Guardar área"
+    },
+    "discard": {
+        "headline-text": "Descartar cambios",
+        "confirm-button": "Sí, descartar cambios",
+        "confirm-tooltip": "Descartar cambios",
+        "info-text": "¿Descartar todos los cambios realizados? ¡Esto no se puede deshacer!"
+    },
+    "theEnd": {
+        "discarded-text": "Todos sus cambios se han perdido para siempre. Ahora puede cerrar el editor.",
+        "startOver-button": "¡Déjame empezar de nuevo!",
+        "startOver-tooltip": "Recargar la página para empezar de nuevo",
+        "info-text": "Cambios guardados con éxito en Opencast. El procesamiento de los cambios puede tardar hasta {{duration}} horas. Ahora puede cerrar el editor.\n"
+    },
+    "workflowSelection": {
+        "saveAndProcess-text": "Guardar y procesar",
+        "selectWF-text": "Seleccione un flujo de trabajo",
+        "noWorkflows-text": "Ocurrió un problema, no hay flujos de trabajo con los que procesar sus cambios.<3/> Por favor, guarde sus cambios y póngase en contacto con su administrador de Opencast.\n",
+        "oneWorkflow-text": "El vídeo se cortará y procesará con el flujo de trabajo \"{{workflow}}\". <3/> Esto tomará algún tiempo.\n",
+        "manyWorkflows-text": "Seleccione qué flujo de trabajo debe usar Opencast para procesar.",
+        "startProcessing-button": "Iniciar proceso",
+        "back-button": "Llévame de vuelta",
+        "selectWF-button": "Haga clic para seleccionar este flujo de trabajo",
+        "selectWF-button-aria": "Pulsa para seleccionar el flujo de trabajo: {{stateName}}\n"
+    },
+    "timeline": {
+        "generateWaveform-text": "Generando forma de onda",
+        "segment-tooltip": "Segmento {{segment}}",
+        "scrubber-text-aria": "Marcador. {{currentTime}}. Segmento activo: {{segment}}. {{segmentStatus}}. Controles: {{moveLeft}} y {{moveRight}} para mover el marcador. {{increase}} y {{decrease}} para aumentar/disminuir el delta de movimiento.\n",
+        "segments-text-aria": "Segmento {{index}}. {{segmentStatus}}. Inicio: {{start}}. Final: {{end}}.\n"
+    },
+    "workflowConfig": {
+        "headline-text": "Configuración del flujo de trabajo",
+        "area-tooltip": "Configuración del flujo de trabajo",
+        "satisfied-text": "¿Satisfecho con su configuración?",
+        "confirm-button": "Iniciar proceso"
+    },
+    "metadata": {
+        "EVENTS-EVENTS-DETAILS-CATALOG-EPISODE": "Metadatos de episodio",
+        "submit-button": "Enviar",
+        "submit-button-tooltip": "Confirmar cambios",
+        "reset-button": "Reestablecer",
+        "reset-button-tooltip": "Deshacer todos los cambios",
+        "submit-helpertext": "Haz cambios a su gusto, luego pulse el botón {{buttonName}}.\nTenga en cuenta que todavía tendrá que empezar el procesamiento para que los cambios surtan efecto.",
+        "validation": {
+            "required": "Requerido",
+            "duration-format": "El formato debe ser HH:MM:SS",
+            "datetime": "Inválido"
+        },
+        "labels": {
+            "title": "Título",
+            "subject": "Tema",
+            "description": "Descripción",
+            "language": "Idioma",
+            "rightsHolder": "Derechos",
+            "license": "Licencia",
+            "isPartOf": "Series",
+            "creator": "Ponente(s)",
+            "contributor": "Colaborador(es)",
+            "startDate": "Fecha de inicio",
+            "duration": "Duración",
+            "location": "Ubicación",
+            "source": "Fuente",
+            "created": "Creado el",
+            "publisher": "Editor",
+            "identifier": "UID"
+        },
+        "language": {
+            "LANGUAGES-SLOVENIAN": "Esloveno",
+            "LANGUAGES-PORTUGESE": "Portugués",
+            "LANGUAGES-ROMANSH": "Rumano",
+            "LANGUAGES-ARABIC": "Árabe",
+            "LANGUAGES-POLISH": "Polaco",
+            "LANGUAGES-ITALIAN": "Italiano",
+            "LANGUAGES-CHINESE": "Chino",
+            "LANGUAGES-FINNISH": "Finlandés",
+            "LANGUAGES-DANISH": "Danés",
+            "LANGUAGES-UKRAINIAN": "Ucraniano",
+            "LANGUAGES-FRENCH": "Francés",
+            "LANGUAGES-SPANISH": "Español",
+            "LANGUAGES-GERMAN_CH": "Alemán suizo",
+            "LANGUAGES-NORWEGIAN": "Noruego",
+            "LANGUAGES-RUSSIAN": "Ruso",
+            "LANGUAGES-JAPANESE": "Japonés",
+            "LANGUAGES-DUTCH": "Neerlandés",
+            "LANGUAGES-TURKISH": "Turco",
+            "LANGUAGES-HINDI": "Hindi",
+            "LANGUAGES-SWEDISH": "Sueco",
+            "LANGUAGES-ENGLISH": "Inglés",
+            "LANGUAGES-GERMAN": "Alemán"
+        },
+        "license": {
+            "EVENTS-LICENSE-CC0": "CC0",
+            "EVENTS-LICENSE-CCBYND": "CC BY-ND",
+            "EVENTS-LICENSE-CCBYNCND": "CC BY-NC-ND",
+            "EVENTS-LICENSE-CCBYNCSA": "CC BY-NC-SA",
+            "EVENTS-LICENSE-ALLRIGHTS": "Todos los derechos reservados",
+            "EVENTS-LICENSE-CCBYSA": "CC BY-SA",
+            "EVENTS-LICENSE-CCBYNC": "CC-BY-NC",
+            "EVENTS-LICENSE-CCBY": "CC-BY"
+        }
+    },
+    "error": {
+        "generic-message": "¡Un error critico ha ocurrido!",
+        "details": "Detalles: "
+    },
+    "landing": {
+        "main-heading": "Bienvenido al editor de vídeos",
+        "contact-admin": "Si intentas editar un vídeo específico pero estás viendo esta página, por favor contacta a tu administrador.",
+        "start-editing-1": "Para empezar a editar, especifique el parámetro ",
+        "start-editing-2": " con el \"id\" del paquete multimedia del vídeo que desea editar.",
+        "link-to-documentation": "Más información sobre cómo configurar el editor de vídeo está disponible en la guía de administración en "
+    },
+    "various": {
+        "error-details-text": "Detalles: {{errorMessage}}\n",
+        "error-noDetails-text": "No hay detalles del error disponibles.",
+        "error-text": "Ha ocurrido un error. Por favor, espere un poco e inténtelo de nuevo.",
+        "goBack-button": "¡De ninguna manera! Volver atrás"
+    },
+    "trackSelection": {
+        "description": "Seleccione qué pistas serán usadas para el procesamiento y publicación.",
+        "trackInactive": "inactivo",
+        "deleteTrackText": "Eliminar pista",
+        "restoreTrackText": "Restaurar pista",
+        "cannotDeleteTrackText": "No se puede eliminar la pista",
+        "deleteTrackTooltip": "No procesar ni publicar esta pista.",
+        "restoreTrackTooltip": "Procesar y publicar esta pista.",
+        "cannotDeleteTrackTooltip": "No se puede eliminar esta pista de la publicación."
+    }
+}

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1,0 +1,183 @@
+{
+    "mainMenu": {
+        "cutting-button": "Cutting",
+        "finish-button": "Finish",
+        "select-tracks-button": "Tracks",
+        "thumbnail-button": "Thumbnail",
+        "metadata-button": "Metadata",
+        "tooltip-aria": "Main Navigation"
+    },
+    "cuttingActions": {
+        "cut-button": "Cut",
+        "cut-tooltip": "Split the segment at the current scrubber position. Hotkey: {{hotkeyName}}",
+        "cut-tooltip-aria": "Cut. Split the segment at the current scrubber position. Hotkey: {{hotkeyName}}.",
+        "delete-button": "Delete",
+        "delete-restore-tooltip": "Mark or unmark the segment at the current position as to be deleted. Hotkey: {{hotkeyName}}",
+        "delete-restore-tooltip-aria": "Delete and Restore. Mark or unmark the segment at the current position as to be deleted. Hotkey: {{hotKeyName}}.",
+        "restore-button": "Restore",
+        "mergeLeft-button": "Merge Left",
+        "mergeLeft-tooltip": "Combine the currently active segment with the segment to its left. Hotkey: {{hotkeyName}}",
+        "mergeLeft-tooltip-aria": "Merge Left. Combine the currently active segment with the segment to its left. Hotkey: {{hotkeyName}}.",
+        "mergeRight-button": "Merge Right",
+        "mergeRight-tooltip": "Combine the currently active segment with the segment to its right. Hotkey: {{hotkeyName}}",
+        "mergeRight-tooltip-aria": "Merge Right. Combine the currently active segment with the segment to its right. Hotkey: {{hotkeyName}}."
+    },
+    "video": {
+        "previewButton": "Preview Mode",
+        "previewButton-tooltip": "Skips deleted segments when playing the video. Currently {{status}}. Hotkey: {{hotkeyName}}",
+        "previewButton-aria": "Enable or disable preview mode. Hotkey: {{hotkeyName}}.",
+        "playButton-tooltip": "Play Button",
+        "time-duration-tooltip": "Playback time and duration",
+        "duration-aria": "Duration",
+        "time-aria": "Current time",
+        "comError-text": "A problem occurred during communication with Opencast.",
+        "loadError-text": "An error has occurred loading this video.",
+        "title-tooltip": "Video Title",
+        "presenter-tooltip": "Video Presenters",
+        "controls-tooltip": "Video Controls"
+    },
+    "finishMenu": {
+        "save-button": "Save changes",
+        "start-button": "Start processing",
+        "discard-button": "Discard changes"
+    },
+    "save": {
+        "headline-text": "Save current project",
+        "confirm-button": "Yes, save changes",
+        "confirmButton-default-tooltip": "Save Button",
+        "confirmButton-attempting-tooltip": "Attempting to save",
+        "confirmButton-success-tooltip": "Saved successfully",
+        "confirmButton-failed-tooltip": "Save failed",
+        "info-text": "The video will not be processed but all cutting information will be stored in Opencast. You can continue your edit later.",
+        "success-text": "Changes saved successfully!",
+        "success-tooltip-aria": "Saved successfully",
+        "saveArea-tooltip": "Save Area"
+    },
+    "discard": {
+        "headline-text": "Discard changes",
+        "confirm-button": "Yes, discard changes",
+        "confirm-tooltip": "Discard changes button",
+        "info-text": "Discard all the changes you made? This cannot be undone!"
+    },
+    "theEnd": {
+        "discarded-text": "All your changes are now lost forever. You can now close the editor.",
+        "startOver-button": "Let me start over!",
+        "startOver-tooltip": "Reload the page to start over",
+        "info-text": "Changes successfully saved to Opencast. Processing your changes may take up to {{duration}} hours. You can now close the editor.\n"
+    },
+    "workflowSelection": {
+        "saveAndProcess-text": "Save and Process",
+        "selectWF-text": "Select a workflow",
+        "noWorkflows-text": "A problem occurred, there are no workflows to process your changes with.<3/> Please save your changes and contact an Opencast Administrator.\n",
+        "oneWorkflow-text": "The video will be cut and processed with the workflow \"{{workflow}}\". <3/> This will take some time.\n",
+        "manyWorkflows-text": "Select which workflow Opencast should use for processing.",
+        "startProcessing-button": "Start processing",
+        "back-button": "Take me back",
+        "selectWF-button": "Click to select this workflow",
+        "selectWF-button-aria": "Press to select the workflow: {{stateName}}\n"
+    },
+    "timeline": {
+        "generateWaveform-text": "Generating Waveform",
+        "segment-tooltip": "Segment {{segment}}",
+        "scrubber-text-aria": "Scrubber. {{currentTime}}. Active segment: {{segment}}. {{segmentStatus}}. Controls: {{moveLeft}} and {{moveRight}} to move the scrubber. {{increase}} and {{decrease}} to increase/decrase the move delta.\n",
+        "segments-text-aria": "Segment {{index}}. {{segmentStatus}}. Start: {{start}}. End: {{end}}.\n"
+    },
+    "workflowConfig": {
+        "headline-text": "Workflow Configuration",
+        "area-tooltip": "Workflow Configuration Area",
+        "satisfied-text": "Satisfied with your configuration?",
+        "confirm-button": "Yes, start processing"
+    },
+    "metadata": {
+        "EVENTS-EVENTS-DETAILS-CATALOG-EPISODE": "Episode Metadata",
+        "submit-button": "Submit",
+        "submit-button-tooltip": "Confirm your changes",
+        "reset-button": "Reset",
+        "reset-button-tooltip": "Undo all your changes",
+        "submit-helpertext": "Make changes as you like, then hit the {{buttonName}} button.\nNote that you will still have to start processing for your changes to take effect.",
+        "validation": {
+            "required": "Required",
+            "duration-format": "Format must be HH:MM:SS",
+            "datetime": "Invalid"
+        },
+        "labels": {
+            "title": "Title",
+            "subject": "Subject",
+            "description": "Description",
+            "language": "Language",
+            "rightsHolder": "Rights",
+            "license": "License",
+            "isPartOf": "Series",
+            "creator": "Presenter(s)",
+            "contributor": "Contributor(s)",
+            "startDate": "Start date",
+            "duration": "Duration",
+            "location": "Location",
+            "source": "Source",
+            "created": "Created",
+            "publisher": "Publisher",
+            "identifier": "UID"
+        },
+        "language": {
+            "LANGUAGES-SLOVENIAN": "Slovenian",
+            "LANGUAGES-PORTUGESE": "Portugese",
+            "LANGUAGES-ROMANSH": "Romansh",
+            "LANGUAGES-ARABIC": "Arabic",
+            "LANGUAGES-POLISH": "Polish",
+            "LANGUAGES-ITALIAN": "Italian",
+            "LANGUAGES-CHINESE": "Chinese",
+            "LANGUAGES-FINNISH": "Finnish",
+            "LANGUAGES-DANISH": "Danish",
+            "LANGUAGES-UKRAINIAN": "Ukrainian",
+            "LANGUAGES-FRENCH": "French",
+            "LANGUAGES-SPANISH": "Spanish",
+            "LANGUAGES-GERMAN_CH": "Swiss German",
+            "LANGUAGES-NORWEGIAN": "Norwegian",
+            "LANGUAGES-RUSSIAN": "Russian",
+            "LANGUAGES-JAPANESE": "Japanese",
+            "LANGUAGES-DUTCH": "Dutch",
+            "LANGUAGES-TURKISH": "Turkish",
+            "LANGUAGES-HINDI": "Hindi",
+            "LANGUAGES-SWEDISH": "Swedish",
+            "LANGUAGES-ENGLISH": "English",
+            "LANGUAGES-GERMAN": "German"
+        },
+        "license": {
+            "EVENTS-LICENSE-CC0": "CC0",
+            "EVENTS-LICENSE-CCBYND": "CC-BY-ND",
+            "EVENTS-LICENSE-CCBYNCND": "CC-BY-NC-ND",
+            "EVENTS-LICENSE-CCBYNCSA": "CC-BY-NC-SA",
+            "EVENTS-LICENSE-ALLRIGHTS": "All rights reserved",
+            "EVENTS-LICENSE-CCBYSA": "CC-BY-SA",
+            "EVENTS-LICENSE-CCBYNC": "CC-BY-NC",
+            "EVENTS-LICENSE-CCBY": "CC-BY"
+        }
+    },
+    "error": {
+        "generic-message": "A critical error has occurred!",
+        "details": "Details: "
+    },
+    "landing": {
+        "main-heading": "Welcome to the Video Editor",
+        "contact-admin": "If you were trying to edit a specific video but are seeing this page, please contact your administrator.",
+        "start-editing-1": "To start editing, specify the parameter ",
+        "start-editing-2": " with the media package id of the video you wish to edit.",
+        "link-to-documentation": "More information about configuring the video editor is available in the administration guide at "
+    },
+    "various": {
+        "error-details-text": "Details: {{errorMessage}}\n",
+        "error-noDetails-text": "No error details are available.",
+        "error-text": "An error has occurred. Please wait a bit and try again.",
+        "goBack-button": "No, take me back"
+    },
+    "trackSelection": {
+        "description": "Select or deselect which tracks are used for processing and publication.",
+        "trackInactive": "inactive",
+        "deleteTrackText": "Delete Track",
+        "restoreTrackText": "Restore Track",
+        "cannotDeleteTrackText": "Cannot Delete Track",
+        "deleteTrackTooltip": "Do not encode and publish this track.",
+        "restoreTrackTooltip": "Encode and publish this track.",
+        "cannotDeleteTrackTooltip": "Cannot remove this track from publication."
+    }
+}

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1,0 +1,183 @@
+{
+    "mainMenu": {
+        "cutting-button": "Cutting",
+        "finish-button": "Finish",
+        "select-tracks-button": "Tracks",
+        "thumbnail-button": "Thumbnail",
+        "metadata-button": "Metadata",
+        "tooltip-aria": "Main Navigation"
+    },
+    "cuttingActions": {
+        "cut-button": "Cut",
+        "cut-tooltip": "Split the segment at the current scrubber position. Hotkey: {{hotkeyName}}",
+        "cut-tooltip-aria": "Cut. Split the segment at the current scrubber position. Hotkey: {{hotkeyName}}.",
+        "delete-button": "Delete",
+        "delete-restore-tooltip": "Mark or unmark the segment at the current position as to be deleted. Hotkey: {{hotkeyName}}",
+        "delete-restore-tooltip-aria": "Delete and Restore. Mark or unmark the segment at the current position as to be deleted. Hotkey: {{hotKeyName}}.",
+        "restore-button": "Restore",
+        "mergeLeft-button": "Merge Left",
+        "mergeLeft-tooltip": "Combine the currently active segment with the segment to its left. Hotkey: {{hotkeyName}}",
+        "mergeLeft-tooltip-aria": "Merge Left. Combine the currently active segment with the segment to its left. Hotkey: {{hotkeyName}}.",
+        "mergeRight-button": "Merge Right",
+        "mergeRight-tooltip": "Combine the currently active segment with the segment to its right. Hotkey: {{hotkeyName}}",
+        "mergeRight-tooltip-aria": "Merge Right. Combine the currently active segment with the segment to its right. Hotkey: {{hotkeyName}}."
+    },
+    "video": {
+        "previewButton": "Preview Mode",
+        "previewButton-tooltip": "Skips deleted segments when playing the video. Currently {{status}}. Hotkey: {{hotkeyName}}",
+        "previewButton-aria": "Enable or disable preview mode. Hotkey: {{hotkeyName}}.",
+        "playButton-tooltip": "Play Button",
+        "time-duration-tooltip": "Playback time and duration",
+        "duration-aria": "Duration",
+        "time-aria": "Current time",
+        "comError-text": "A problem occurred during communication with Opencast.",
+        "loadError-text": "An error has occurred loading this video.",
+        "title-tooltip": "Video Title",
+        "presenter-tooltip": "Video Presenters",
+        "controls-tooltip": "Video Controls"
+    },
+    "finishMenu": {
+        "save-button": "Save changes",
+        "start-button": "Start processing",
+        "discard-button": "Discard changes"
+    },
+    "save": {
+        "headline-text": "Save current project",
+        "confirm-button": "Yes, save changes",
+        "confirmButton-default-tooltip": "Save Button",
+        "confirmButton-attempting-tooltip": "Attempting to save",
+        "confirmButton-success-tooltip": "Saved successfully",
+        "confirmButton-failed-tooltip": "Save failed",
+        "info-text": "The video will not be processed but all cutting information will be stored in Opencast. You can continue your edit later.",
+        "success-text": "Changes saved successfully!",
+        "success-tooltip-aria": "Saved successfully",
+        "saveArea-tooltip": "Save Area"
+    },
+    "discard": {
+        "headline-text": "Discard changes",
+        "confirm-button": "Yes, discard changes",
+        "confirm-tooltip": "Discard changes button",
+        "info-text": "Discard all the changes you made? This cannot be undone!"
+    },
+    "theEnd": {
+        "discarded-text": "All your changes are now lost forever. You can now close the editor.",
+        "startOver-button": "Let me start over!",
+        "startOver-tooltip": "Reload the page to start over",
+        "info-text": "Changes successfully saved to Opencast. Processing your changes may take up to {{duration}} hours. You can now close the editor.\n"
+    },
+    "workflowSelection": {
+        "saveAndProcess-text": "Save and Process",
+        "selectWF-text": "Select a workflow",
+        "noWorkflows-text": "A problem occurred, there are no workflows to process your changes with.<3/> Please save your changes and contact an Opencast Administrator.\n",
+        "oneWorkflow-text": "The video will be cut and processed with the workflow \"{{workflow}}\". <3/> This will take some time.\n",
+        "manyWorkflows-text": "Select which workflow Opencast should use for processing.",
+        "startProcessing-button": "Start processing",
+        "back-button": "Take me back",
+        "selectWF-button": "Click to select this workflow",
+        "selectWF-button-aria": "Press to select the workflow: {{stateName}}\n"
+    },
+    "timeline": {
+        "generateWaveform-text": "Generating Waveform",
+        "segment-tooltip": "Segment {{segment}}",
+        "scrubber-text-aria": "Scrubber. {{currentTime}}. Active segment: {{segment}}. {{segmentStatus}}. Controls: {{moveLeft}} and {{moveRight}} to move the scrubber. {{increase}} and {{decrease}} to increase/decrase the move delta.\n",
+        "segments-text-aria": "Segment {{index}}. {{segmentStatus}}. Start: {{start}}. End: {{end}}.\n"
+    },
+    "workflowConfig": {
+        "headline-text": "Workflow Configuration",
+        "area-tooltip": "Workflow Configuration Area",
+        "satisfied-text": "Satisfied with your configuration?",
+        "confirm-button": "Yes, start processing"
+    },
+    "metadata": {
+        "EVENTS-EVENTS-DETAILS-CATALOG-EPISODE": "Episode Metadata",
+        "submit-button": "Submit",
+        "submit-button-tooltip": "Confirm your changes",
+        "reset-button": "Reset",
+        "reset-button-tooltip": "Undo all your changes",
+        "submit-helpertext": "Make changes as you like, then hit the {{buttonName}} button.\nNote that you will still have to start processing for your changes to take effect.",
+        "validation": {
+            "required": "Required",
+            "duration-format": "Format must be HH:MM:SS",
+            "datetime": "Invalid"
+        },
+        "labels": {
+            "title": "Title",
+            "subject": "Subject",
+            "description": "Description",
+            "language": "Language",
+            "rightsHolder": "Rights",
+            "license": "License",
+            "isPartOf": "Series",
+            "creator": "Presenter(s)",
+            "contributor": "Contributor(s)",
+            "startDate": "Start date",
+            "duration": "Duration",
+            "location": "Location",
+            "source": "Source",
+            "created": "Created",
+            "publisher": "Publisher",
+            "identifier": "UID"
+        },
+        "language": {
+            "LANGUAGES-SLOVENIAN": "Slovenian",
+            "LANGUAGES-PORTUGESE": "Portugese",
+            "LANGUAGES-ROMANSH": "Romansh",
+            "LANGUAGES-ARABIC": "Arabic",
+            "LANGUAGES-POLISH": "Polish",
+            "LANGUAGES-ITALIAN": "Italian",
+            "LANGUAGES-CHINESE": "Chinese",
+            "LANGUAGES-FINNISH": "Finnish",
+            "LANGUAGES-DANISH": "Danish",
+            "LANGUAGES-UKRAINIAN": "Ukrainian",
+            "LANGUAGES-FRENCH": "French",
+            "LANGUAGES-SPANISH": "Spanish",
+            "LANGUAGES-GERMAN_CH": "Swiss German",
+            "LANGUAGES-NORWEGIAN": "Norwegian",
+            "LANGUAGES-RUSSIAN": "Russian",
+            "LANGUAGES-JAPANESE": "Japanese",
+            "LANGUAGES-DUTCH": "Dutch",
+            "LANGUAGES-TURKISH": "Turkish",
+            "LANGUAGES-HINDI": "Hindi",
+            "LANGUAGES-SWEDISH": "Swedish",
+            "LANGUAGES-ENGLISH": "English",
+            "LANGUAGES-GERMAN": "German"
+        },
+        "license": {
+            "EVENTS-LICENSE-CC0": "CC0",
+            "EVENTS-LICENSE-CCBYND": "CC-BY-ND",
+            "EVENTS-LICENSE-CCBYNCND": "CC-BY-NC-ND",
+            "EVENTS-LICENSE-CCBYNCSA": "CC-BY-NC-SA",
+            "EVENTS-LICENSE-ALLRIGHTS": "All rights reserved",
+            "EVENTS-LICENSE-CCBYSA": "CC-BY-SA",
+            "EVENTS-LICENSE-CCBYNC": "CC-BY-NC",
+            "EVENTS-LICENSE-CCBY": "CC-BY"
+        }
+    },
+    "error": {
+        "generic-message": "A critical error has occurred!",
+        "details": "Details: "
+    },
+    "landing": {
+        "main-heading": "Welcome to the Video Editor",
+        "contact-admin": "If you were trying to edit a specific video but are seeing this page, please contact your administrator.",
+        "start-editing-1": "To start editing, specify the parameter ",
+        "start-editing-2": " with the media package id of the video you wish to edit.",
+        "link-to-documentation": "More information about configuring the video editor is available in the administration guide at "
+    },
+    "various": {
+        "error-details-text": "Details: {{errorMessage}}\n",
+        "error-noDetails-text": "No error details are available.",
+        "error-text": "An error has occurred. Please wait a bit and try again.",
+        "goBack-button": "No, take me back"
+    },
+    "trackSelection": {
+        "description": "Select or deselect which tracks are used for processing and publication.",
+        "trackInactive": "inactive",
+        "deleteTrackText": "Delete Track",
+        "restoreTrackText": "Restore Track",
+        "cannotDeleteTrackText": "Cannot Delete Track",
+        "deleteTrackTooltip": "Do not encode and publish this track.",
+        "restoreTrackTooltip": "Encode and publish this track.",
+        "cannotDeleteTrackTooltip": "Cannot remove this track from publication."
+    }
+}

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1,0 +1,183 @@
+{
+    "mainMenu": {
+        "cutting-button": "Knippen",
+        "finish-button": "Opslaan",
+        "select-tracks-button": "Sporen",
+        "thumbnail-button": "Miniatuurafbeelding",
+        "metadata-button": "Metadata",
+        "tooltip-aria": "Hoofdnavigatie"
+    },
+    "cuttingActions": {
+        "cut-button": "Knippen",
+        "cut-tooltip": "Splits het segment op de huidige scrubber positie. Sneltoets: {{hotkeyName}}",
+        "cut-tooltip-aria": "Knippen. Splits het segment op de huidige scrubber positie. Sneltoets: {{hotkeyName}}.",
+        "delete-button": "Verwijder",
+        "delete-restore-tooltip": "Markeer of verwijder het segment op de huidige positie om te worden verwijderd. Sneltoets: {{hotkeyName}}",
+        "delete-restore-tooltip-aria": "Verwijderen en herstellen. Markeer of verwijder het segment op de huidige positie om te worden verwijderd. Sneltoets: {{hotKeyName}}.",
+        "restore-button": "Herstellen",
+        "mergeLeft-button": "Links samenvoegen",
+        "mergeLeft-tooltip": "Combineer het momenteel actieve segment met het segment aan de linkerkant. Sneltoets: {{hotkeyName}}",
+        "mergeLeft-tooltip-aria": "Links samenvoegen. Combineer het momenteel actieve segment met het segment aan de linkerkant. Sneltoets: {{hotkeyName}}.",
+        "mergeRight-button": "Rechts samenvoegen",
+        "mergeRight-tooltip": "Combineer het momenteel actieve segment met het segment aan de rechterkant. Sneltoets: {{hotkeyName}}",
+        "mergeRight-tooltip-aria": "Rechts samenvoegen. Combineer het momenteel actieve segment met het segment aan de rechterkant. Sneltoets: {{hotkeyName}}."
+    },
+    "video": {
+        "previewButton": "Voorvertoningsmodus",
+        "previewButton-tooltip": "Slaat verwijderde segmenten over tijdens het afspelen van de video. Momenteel {{status}}. Snelkey: {{hotkeyName}}",
+        "previewButton-aria": "In- of uitschakelen voorvertoning modus. Sneltoets: {{hotkeyName}}.",
+        "playButton-tooltip": "Afspeelknop",
+        "time-duration-tooltip": "Afspeeltijd en duur",
+        "duration-aria": "Duur",
+        "time-aria": "Actuele tijd",
+        "comError-text": "Er is een probleem opgetreden tijdens de communicatie met Opencast.",
+        "loadError-text": "Er is een fout opgetreden tijdens het laden van deze video.",
+        "title-tooltip": "Titel van de video",
+        "presenter-tooltip": "Video presentatoren",
+        "controls-tooltip": "Videobesturing"
+    },
+    "finishMenu": {
+        "save-button": "Wijzigingen opslaan",
+        "start-button": "Start verwerking",
+        "discard-button": "Annuleren"
+    },
+    "save": {
+        "headline-text": "Huidig project opslaan",
+        "confirm-button": "Ja, wijzigingen opslaan",
+        "confirmButton-default-tooltip": "Opslagknop",
+        "confirmButton-attempting-tooltip": "Bezig met opslaan",
+        "confirmButton-success-tooltip": "Succesvol opgeslagen",
+        "confirmButton-failed-tooltip": "Opslaan is mislukt",
+        "info-text": "De video wordt niet verwerkt, maar alle snijgegevens worden opgeslagen in Opencast. U kunt later doorgaan met uw bewerking.",
+        "success-text": "Wijzigingen succesvol opgeslagen!",
+        "success-tooltip-aria": "Succesvol opgeslagen",
+        "saveArea-tooltip": "Gebied opslaan"
+    },
+    "discard": {
+        "headline-text": "Annuleren",
+        "confirm-button": "Ja, wijzigingen negeren",
+        "confirm-tooltip": "Wijzigingen negeren knop",
+        "info-text": "Alle wijzigingen ongedaan maken? Dit kan niet ongedaan worden gemaakt!"
+    },
+    "theEnd": {
+        "discarded-text": "Al uw wijzigingen zijn nu voorgoed verloren. U kunt nu de editor sluiten.",
+        "startOver-button": "Opnieuw beginnen!",
+        "startOver-tooltip": "Herlaad de pagina om opnieuw te beginnen",
+        "info-text": "Wijzigingen succesvol opgeslagen in Opencast. Het verwerken van uw wijzigingen kan {{duration}} uren duren. U kunt nu de editor sluiten.\n"
+    },
+    "workflowSelection": {
+        "saveAndProcess-text": "Opslaan en verwerken",
+        "selectWF-text": "Selecteer een workflow",
+        "noWorkflows-text": "Er is een probleem opgetreden. Er zijn geen workflows om u wijzigingen te verwerken.<3/> Sla u wijzigingen op en neem contact op met een Opencast beheerder.\n",
+        "oneWorkflow-text": "De video wordt geknipt en verwerkt met de workflow \"{{workflow}}\". <3/> Dit kost enige tijd.\n",
+        "manyWorkflows-text": "Selecteer welke workflow Opencast moet gebruiken voor verwerking.",
+        "startProcessing-button": "Start verwerking",
+        "back-button": "Breng me terug",
+        "selectWF-button": "Klik om deze workflow te selecteren",
+        "selectWF-button-aria": "Druk om de workflow te selecteren: {{stateName}}\n"
+    },
+    "timeline": {
+        "generateWaveform-text": "Waveform genereren",
+        "segment-tooltip": "Segment {{segment}}",
+        "scrubber-text-aria": "Scrubber. {{currentTime}}. Actief segment: {{segment}}. {{segmentStatus}}. Controleert: {{moveLeft}} en {{moveRight}} om het scrupules te verplaatsen. {{increase}} en {{decrease}} om de verplaatsingsdelta te vergroten of te vertekenen.\n",
+        "segments-text-aria": "Segment {{index}}. {{segmentStatus}}. Begin: {{start}}. Eindigt: {{end}}.\n"
+    },
+    "workflowConfig": {
+        "headline-text": "Workflow configuratie",
+        "area-tooltip": "Workflow configuratiegebied",
+        "satisfied-text": "Tevreden met je configuratie?",
+        "confirm-button": "Ja, begin met verwerken"
+    },
+    "metadata": {
+        "EVENTS-EVENTS-DETAILS-CATALOG-EPISODE": "Aflevering Metadata",
+        "submit-button": "Verzenden",
+        "submit-button-tooltip": "Wijzigingen bevestigen",
+        "reset-button": "Reset",
+        "reset-button-tooltip": "Al u wijzigingen ongedaan maken",
+        "submit-helpertext": "Maak wijzigingen zoals u wilt, en druk dan op de {{buttonName}} knop.\nMerk op dat u nog steeds moet beginnen met verwerken om de wijzigingen door te voeren.",
+        "validation": {
+            "required": "Verplicht",
+            "duration-format": "Formaat moet HH:MM:SS zijn",
+            "datetime": "Ongeldig"
+        },
+        "labels": {
+            "title": "Titel",
+            "subject": "Onderwerp",
+            "description": "Beschrijving",
+            "language": "Taal",
+            "rightsHolder": "Rechten",
+            "license": "Licentie",
+            "isPartOf": "Series",
+            "creator": "Presentator(en)",
+            "contributor": "Bijdrager(s)",
+            "startDate": "Startdatum",
+            "duration": "Duur",
+            "location": "Locatie",
+            "source": "Bron",
+            "created": "Aangemaakt",
+            "publisher": "Uitgever",
+            "identifier": "UID"
+        },
+        "language": {
+            "LANGUAGES-SLOVENIAN": "Sloveens",
+            "LANGUAGES-PORTUGESE": "Portugees",
+            "LANGUAGES-ROMANSH": "Reto-Romaans",
+            "LANGUAGES-ARABIC": "Arabisch",
+            "LANGUAGES-POLISH": "Pools",
+            "LANGUAGES-ITALIAN": "Italiaans",
+            "LANGUAGES-CHINESE": "Chinees",
+            "LANGUAGES-FINNISH": "Fins",
+            "LANGUAGES-DANISH": "Deens",
+            "LANGUAGES-UKRAINIAN": "Oekraïens",
+            "LANGUAGES-FRENCH": "Frans",
+            "LANGUAGES-SPANISH": "Spaans",
+            "LANGUAGES-GERMAN_CH": "Zwitsers Duits",
+            "LANGUAGES-NORWEGIAN": "Noors",
+            "LANGUAGES-RUSSIAN": "Russisch",
+            "LANGUAGES-JAPANESE": "Japans",
+            "LANGUAGES-DUTCH": "Nederlands",
+            "LANGUAGES-TURKISH": "Turks",
+            "LANGUAGES-HINDI": "Hindi",
+            "LANGUAGES-SWEDISH": "Zweeds",
+            "LANGUAGES-ENGLISH": "Engels",
+            "LANGUAGES-GERMAN": "Duits"
+        },
+        "license": {
+            "EVENTS-LICENSE-CC0": "CC0",
+            "EVENTS-LICENSE-CCBYND": "CC-BY-ND",
+            "EVENTS-LICENSE-CCBYNCND": "CC-BY-NC-ND",
+            "EVENTS-LICENSE-CCBYNCSA": "CC-BY-NC-SA",
+            "EVENTS-LICENSE-ALLRIGHTS": "Alle rechten voorbehouden",
+            "EVENTS-LICENSE-CCBYSA": "CC-BY-SA",
+            "EVENTS-LICENSE-CCBYNC": "CC-BY-NC",
+            "EVENTS-LICENSE-CCBY": "CC-BY"
+        }
+    },
+    "error": {
+        "generic-message": "Er is een kritische fout opgetreden!",
+        "details": "Details: "
+    },
+    "landing": {
+        "main-heading": "Welkom in de Video Editor",
+        "contact-admin": "Als u een specifieke video probeerde te bewerken maar deze pagina ziet, neem dan contact op met uw beheerder.",
+        "start-editing-1": "Om te beginnen met bewerken, geef de parameter aan ",
+        "start-editing-2": " met het ID van het media-pakket van de video die u wilt bewerken.",
+        "link-to-documentation": "Er is meer informatie over het configureren van de video-editor beschikbaar in de beheergids op "
+    },
+    "various": {
+        "error-details-text": "Details: {{errorMessage}}\n",
+        "error-noDetails-text": "Er zijn geen foutgegevens beschikbaar.",
+        "error-text": "Er is een fout opgetreden. Wacht even en probeer het opnieuw.",
+        "goBack-button": "Nee, breng me terug"
+    },
+    "trackSelection": {
+        "description": "Selecteer of deselecteer welke sporen worden gebruikt voor verwerking en publicatie.",
+        "trackInactive": "inactief",
+        "deleteTrackText": "Verwijder spoor",
+        "restoreTrackText": "Herstel spoor",
+        "cannotDeleteTrackText": "Spoor kan niet verwijdert worden",
+        "deleteTrackTooltip": "Deze spoor niet coderen en publiceren.",
+        "restoreTrackTooltip": "Encodeer en publiceer deze spoor.",
+        "cannotDeleteTrackTooltip": "Kan deze spoor niet uit de publicatie verwijderen."
+    }
+}

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -1,0 +1,183 @@
+{
+    "mainMenu": {
+        "cutting-button": "Cutting",
+        "finish-button": "Finish",
+        "select-tracks-button": "Tracks",
+        "thumbnail-button": "Thumbnail",
+        "metadata-button": "Metadata",
+        "tooltip-aria": "Main Navigation"
+    },
+    "cuttingActions": {
+        "cut-button": "Cut",
+        "cut-tooltip": "Split the segment at the current scrubber position. Hotkey: {{hotkeyName}}",
+        "cut-tooltip-aria": "Cut. Split the segment at the current scrubber position. Hotkey: {{hotkeyName}}.",
+        "delete-button": "Delete",
+        "delete-restore-tooltip": "Mark or unmark the segment at the current position as to be deleted. Hotkey: {{hotkeyName}}",
+        "delete-restore-tooltip-aria": "Delete and Restore. Mark or unmark the segment at the current position as to be deleted. Hotkey: {{hotKeyName}}.",
+        "restore-button": "Restore",
+        "mergeLeft-button": "Merge Left",
+        "mergeLeft-tooltip": "Combine the currently active segment with the segment to its left. Hotkey: {{hotkeyName}}",
+        "mergeLeft-tooltip-aria": "Merge Left. Combine the currently active segment with the segment to its left. Hotkey: {{hotkeyName}}.",
+        "mergeRight-button": "Merge Right",
+        "mergeRight-tooltip": "Combine the currently active segment with the segment to its right. Hotkey: {{hotkeyName}}",
+        "mergeRight-tooltip-aria": "Merge Right. Combine the currently active segment with the segment to its right. Hotkey: {{hotkeyName}}."
+    },
+    "video": {
+        "previewButton": "Preview Mode",
+        "previewButton-tooltip": "Skips deleted segments when playing the video. Currently {{status}}. Hotkey: {{hotkeyName}}",
+        "previewButton-aria": "Enable or disable preview mode. Hotkey: {{hotkeyName}}.",
+        "playButton-tooltip": "Play Button",
+        "time-duration-tooltip": "Playback time and duration",
+        "duration-aria": "Duration",
+        "time-aria": "Current time",
+        "comError-text": "A problem occurred during communication with Opencast.",
+        "loadError-text": "An error has occurred loading this video.",
+        "title-tooltip": "Video Title",
+        "presenter-tooltip": "Video Presenters",
+        "controls-tooltip": "Video Controls"
+    },
+    "finishMenu": {
+        "save-button": "Save changes",
+        "start-button": "Start processing",
+        "discard-button": "Discard changes"
+    },
+    "save": {
+        "headline-text": "Save current project",
+        "confirm-button": "Yes, save changes",
+        "confirmButton-default-tooltip": "Save Button",
+        "confirmButton-attempting-tooltip": "Attempting to save",
+        "confirmButton-success-tooltip": "Saved successfully",
+        "confirmButton-failed-tooltip": "Save failed",
+        "info-text": "The video will not be processed but all cutting information will be stored in Opencast. You can continue your edit later.",
+        "success-text": "Changes saved successfully!",
+        "success-tooltip-aria": "Saved successfully",
+        "saveArea-tooltip": "Save Area"
+    },
+    "discard": {
+        "headline-text": "Discard changes",
+        "confirm-button": "Yes, discard changes",
+        "confirm-tooltip": "Discard changes button",
+        "info-text": "Discard all the changes you made? This cannot be undone!"
+    },
+    "theEnd": {
+        "discarded-text": "All your changes are now lost forever. You can now close the editor.",
+        "startOver-button": "Let me start over!",
+        "startOver-tooltip": "Reload the page to start over",
+        "info-text": "Changes successfully saved to Opencast. Processing your changes may take up to {{duration}} hours. You can now close the editor.\n"
+    },
+    "workflowSelection": {
+        "saveAndProcess-text": "Save and Process",
+        "selectWF-text": "Select a workflow",
+        "noWorkflows-text": "A problem occurred, there are no workflows to process your changes with.<3/> Please save your changes and contact an Opencast Administrator.\n",
+        "oneWorkflow-text": "The video will be cut and processed with the workflow \"{{workflow}}\". <3/> This will take some time.\n",
+        "manyWorkflows-text": "Select which workflow Opencast should use for processing.",
+        "startProcessing-button": "Start processing",
+        "back-button": "Take me back",
+        "selectWF-button": "Click to select this workflow",
+        "selectWF-button-aria": "Press to select the workflow: {{stateName}}\n"
+    },
+    "timeline": {
+        "generateWaveform-text": "Generating Waveform",
+        "segment-tooltip": "Segment {{segment}}",
+        "scrubber-text-aria": "Scrubber. {{currentTime}}. Active segment: {{segment}}. {{segmentStatus}}. Controls: {{moveLeft}} and {{moveRight}} to move the scrubber. {{increase}} and {{decrease}} to increase/decrase the move delta.\n",
+        "segments-text-aria": "Segment {{index}}. {{segmentStatus}}. Start: {{start}}. End: {{end}}.\n"
+    },
+    "workflowConfig": {
+        "headline-text": "Workflow Configuration",
+        "area-tooltip": "Workflow Configuration Area",
+        "satisfied-text": "Satisfied with your configuration?",
+        "confirm-button": "Yes, start processing"
+    },
+    "metadata": {
+        "EVENTS-EVENTS-DETAILS-CATALOG-EPISODE": "Episode Metadata",
+        "submit-button": "Submit",
+        "submit-button-tooltip": "Confirm your changes",
+        "reset-button": "Reset",
+        "reset-button-tooltip": "Undo all your changes",
+        "submit-helpertext": "Make changes as you like, then hit the {{buttonName}} button.\nNote that you will still have to start processing for your changes to take effect.",
+        "validation": {
+            "required": "Required",
+            "duration-format": "Format must be HH:MM:SS",
+            "datetime": "Invalid"
+        },
+        "labels": {
+            "title": "Title",
+            "subject": "Subject",
+            "description": "Description",
+            "language": "Language",
+            "rightsHolder": "Rights",
+            "license": "License",
+            "isPartOf": "Series",
+            "creator": "Presenter(s)",
+            "contributor": "Contributor(s)",
+            "startDate": "Start date",
+            "duration": "Duration",
+            "location": "Location",
+            "source": "Source",
+            "created": "Created",
+            "publisher": "Publisher",
+            "identifier": "UID"
+        },
+        "language": {
+            "LANGUAGES-SLOVENIAN": "Slovenian",
+            "LANGUAGES-PORTUGESE": "Portugese",
+            "LANGUAGES-ROMANSH": "Romansh",
+            "LANGUAGES-ARABIC": "Arabic",
+            "LANGUAGES-POLISH": "Polish",
+            "LANGUAGES-ITALIAN": "Italian",
+            "LANGUAGES-CHINESE": "Chinese",
+            "LANGUAGES-FINNISH": "Finnish",
+            "LANGUAGES-DANISH": "Danish",
+            "LANGUAGES-UKRAINIAN": "Ukrainian",
+            "LANGUAGES-FRENCH": "French",
+            "LANGUAGES-SPANISH": "Spanish",
+            "LANGUAGES-GERMAN_CH": "Swiss German",
+            "LANGUAGES-NORWEGIAN": "Norwegian",
+            "LANGUAGES-RUSSIAN": "Russian",
+            "LANGUAGES-JAPANESE": "Japanese",
+            "LANGUAGES-DUTCH": "Dutch",
+            "LANGUAGES-TURKISH": "Turkish",
+            "LANGUAGES-HINDI": "Hindi",
+            "LANGUAGES-SWEDISH": "Swedish",
+            "LANGUAGES-ENGLISH": "English",
+            "LANGUAGES-GERMAN": "German"
+        },
+        "license": {
+            "EVENTS-LICENSE-CC0": "CC0",
+            "EVENTS-LICENSE-CCBYND": "CC-BY-ND",
+            "EVENTS-LICENSE-CCBYNCND": "CC-BY-NC-ND",
+            "EVENTS-LICENSE-CCBYNCSA": "CC-BY-NC-SA",
+            "EVENTS-LICENSE-ALLRIGHTS": "All rights reserved",
+            "EVENTS-LICENSE-CCBYSA": "CC-BY-SA",
+            "EVENTS-LICENSE-CCBYNC": "CC-BY-NC",
+            "EVENTS-LICENSE-CCBY": "CC-BY"
+        }
+    },
+    "error": {
+        "generic-message": "A critical error has occurred!",
+        "details": "Details: "
+    },
+    "landing": {
+        "main-heading": "Welcome to the Video Editor",
+        "contact-admin": "If you were trying to edit a specific video but are seeing this page, please contact your administrator.",
+        "start-editing-1": "To start editing, specify the parameter ",
+        "start-editing-2": " with the media package id of the video you wish to edit.",
+        "link-to-documentation": "More information about configuring the video editor is available in the administration guide at "
+    },
+    "various": {
+        "error-details-text": "Details: {{errorMessage}}\n",
+        "error-noDetails-text": "No error details are available.",
+        "error-text": "An error has occurred. Please wait a bit and try again.",
+        "goBack-button": "No, take me back"
+    },
+    "trackSelection": {
+        "description": "Select or deselect which tracks are used for processing and publication.",
+        "trackInactive": "inactive",
+        "deleteTrackText": "Delete Track",
+        "restoreTrackText": "Restore Track",
+        "cannotDeleteTrackText": "Cannot Delete Track",
+        "deleteTrackTooltip": "Do not encode and publish this track.",
+        "restoreTrackTooltip": "Encode and publish this track.",
+        "cannotDeleteTrackTooltip": "Cannot remove this track from publication."
+    }
+}


### PR DESCRIPTION
This patch adds a workflow to automatically update the translations on a
weekly basis by downloading the current state from Crowding and
committing them to the repository.

This fixes #406