### PR TITLE
Actually Mock Data for Playwright Tests

### DIFF
--- a/.github/workflows/playwright-test.yml
+++ b/.github/workflows/playwright-test.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Prepare configuration
       run: >
-        sed
+        sed -i
         's_https://develop.opencast.org_http://localhost:3000_'
         public/editor-settings.toml
 


### PR DESCRIPTION
This patch fixes the configuration for using the mock data in the
PlayWright tests on GitHub Actions.