### PR TITLE
Relax Playwright tests for the navigation bar

### DIFF
--- a/tests/navigation.test.ts
+++ b/tests/navigation.test.ts
@@ -7,19 +7,12 @@ test('Test: Navigation', async ({ page, baseURL }) => {
     await expect(page).toHaveTitle("Opencast Editor");
 
     // checks if Navbar on left has 4 elements
-    const locator = page.locator('#root > div > div > nav > li');
-    await expect(locator).toHaveCount(4);
-
-    // Navigation to Metadata
-    await page.click('li[role="menuitem"]:has-text("Metadata")');
-
-    // Navigation to Tracks
-    await page.click('li[role="menuitem"]:has-text("Tracks")');
+    const length = await page.locator('#root > div > div > nav > li').count();
+    expect(length >= 2).toBeTruthy();
 
     // Navigation to Finish
     await page.click('li[role="menuitem"]:has-text("Finish")');
 
     // Navigation to Cutting
     await page.click('li[role="menuitem"]:has-text("Cutting")');
-
 });


### PR DESCRIPTION
Currently the Playwright tests for the navigation bar expect four specific menu items to be present. However, every menu item besides "Cutting" and "Finish" is configurable to be present or not. Therefore I'd like to propose to only check for the actually required menu items, instead of some arbitrarily defined set.