### PR TITLE
Get rid of stand-alone naming leftovers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Opencast Video Editor
 [![Demo deployment](https://img.shields.io/badge/demo-editor.opencast.org-blue)
 ](https://editor.opencast.org)
 
-The Opencast Video Editor is a stand-alone tool included by [Opencast](https://opencast.org) to cut and arrange recordings.
+The Opencast Video Editor is a tool included by [Opencast](https://opencast.org) to cut and arrange recordings.
 
 
 Quick Test

--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description"
-          content="Opencast's stand-alone video editor" />
+          content="Opencast's video editor" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -9,7 +9,7 @@
     }
   ],
   "start_url": ".",
-  "display": "standalone",
+  "display": "minimal-ui",
   "theme_color": "#000000",
   "background_color": "#ffffff"
 }


### PR DESCRIPTION
Calling this editor the "Standalone Editor" has long been abandoned. This PR removes the last remaining references to that.

Resolves #299