### PR TITLE
Display waveform images from the backend instead of generating them

### DIFF
--- a/src/main/Timeline.tsx
+++ b/src/main/Timeline.tsx
@@ -8,7 +8,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { Segment, httpRequestState, MainMenuStateNames } from '../types'
 import {
   selectIsPlaying, selectCurrentlyAt, selectSegments, selectActiveSegmentIndex, selectDuration,
-  setIsPlaying, selectVideoURL, setCurrentlyAt, setClickTriggered
+  setIsPlaying, selectVideoURL, setCurrentlyAt, setClickTriggered, selectWaveformImages, setWaveformImages
 } from '../redux/videoSlice'
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -324,11 +324,12 @@ const Waveforms: React.FC<{}> = () => {
 
   const { t } = useTranslation();
 
+  const dispatch = useDispatch();
   const videoURLs = useSelector(selectVideoURL)
   const videoURLStatus = useSelector((state: { videoState: { status: httpRequestState["status"] } }) => state.videoState.status);
 
   // Update based on current fetching status
-  const [images, setImages] = useState<string[]>([])
+  const images = useSelector(selectWaveformImages)
   const [waveformWorkerError, setWaveformWorkerError] = useState<boolean>(false)
 
   const waveformDisplayTestStyle = css({
@@ -345,7 +346,11 @@ const Waveforms: React.FC<{}> = () => {
   // When the URLs to the videos are fetched, generate waveforms
   useEffect( () => {
     if (videoURLStatus === 'success') {
-      const images: string[] = []    // Store local paths to image files
+      if (images.length > 0) {
+        return
+      }
+
+      const newImages: string[] = []    // Store local paths to image files
       let waveformsProcessed : number = 0  // Counter for checking if all workers are done
 
       // Only display the waveform of the first video we get
@@ -372,11 +377,11 @@ const Waveforms: React.FC<{}> = () => {
 
           // When done, save path to generated waveform img
           waveformWorker.oncomplete = function(image: any, numSamples: any) {
-            images.push(image)
+            newImages.push(image)
             waveformsProcessed++
             // If all images are generated, rerender
             if (waveformsProcessed === array.length) {
-              setImages(images)
+              dispatch(setWaveformImages(newImages))
             }
           }
         }
@@ -384,15 +389,16 @@ const Waveforms: React.FC<{}> = () => {
         xhr.send()
       })
     }
-  }, [videoURLStatus, videoURLs]);
+  }, [dispatch, images, videoURLStatus, videoURLs]);
 
 
   const renderImages = () => {
     if (images.length > 0) {
       return (
-        images.map((image, index) =>
-          <img key={index} alt='Waveform' src={image ? image : ""} css={{minHeight: 0}}></img>
-        )
+        <img alt='Waveform' src={images[0]} css={{minHeight: 0}}></img>
+        // images.map((image, index) =>
+        //   <img key={index} alt='Waveform' src={image ? image : ""} css={{minHeight: 0}}></img>
+        // )
       );
     } else if (waveformWorkerError) {
       return (

--- a/src/redux/videoSlice.ts
+++ b/src/redux/videoSlice.ts
@@ -18,6 +18,7 @@ export interface video {
   selectedWorkflowIndex: number,  // Index of the currently selected workflow
   aspectRatios: {width: number, height: number}[],  // Aspect ratios of every video
   hasChanges: boolean             // Did user make changes in cutting view since last save
+  waveformImages: string[]
 
   videoURLs: string[],  // Links to each video
   videoCount: number,   // Total number of videos
@@ -39,6 +40,7 @@ export const initialState: video & httpRequestState = {
   clickTriggered: false,
   aspectRatios: [],
   hasChanges: false,
+  waveformImages: [],
 
   videoURLs: [],
   videoCount: 0,
@@ -120,6 +122,9 @@ export const videoSlice = createSlice({
     setHasChanges: (state, action: PayloadAction<video["hasChanges"]>) => {
       state.hasChanges = action.payload
     },
+    setWaveformImages: (state, action: PayloadAction<video["waveformImages"]>) => {
+      state.waveformImages = action.payload
+    },
     cut: (state) => {
       // If we're exactly between two segments, we can't split the current segment
       if (state.segments[state.activeSegmentIndex].start === state.currentlyAt ||
@@ -194,6 +199,7 @@ export const videoSlice = createSlice({
         state.workflows = action.payload.workflows.sort((n1: { displayOrder: number; },n2: { displayOrder: number; }) => {
           return n1.displayOrder - n2.displayOrder;
         });
+        state.waveformImages = action.payload.waveformURIs ? action.payload.waveformURIs : state.waveformImages
 
         state.aspectRatios = new Array(state.videoCount)
     })
@@ -292,8 +298,8 @@ const calculateTotalAspectRatio = (aspectRatios: video["aspectRatios"]) => {
 }
 
 export const { setTrackEnabled, setIsPlaying, setIsPlayPreview, setCurrentlyAt, setCurrentlyAtInSeconds,
-  addSegment, setAspectRatio, setHasChanges, cut, markAsDeletedOrAlive, setSelectedWorkflowIndex, mergeLeft, mergeRight,
-  setPreviewTriggered, setClickTriggered } = videoSlice.actions
+  addSegment, setAspectRatio, setHasChanges, setWaveformImages, cut, markAsDeletedOrAlive, setSelectedWorkflowIndex,
+  mergeLeft, mergeRight, setPreviewTriggered, setClickTriggered } = videoSlice.actions
 
 // Export selectors
 // Selectors mainly pertaining to the video state
@@ -321,6 +327,8 @@ export const selectSelectedWorkflowIndex = (state: { videoState:
   state.videoState.selectedWorkflowIndex
 export const hasChanges = (state: { videoState: { hasChanges: video["hasChanges"]; }; }) =>
   state.videoState.hasChanges
+export const selectWaveformImages = (state: { videoState: { waveformImages: video["waveformImages"]; }; }) =>
+  state.videoState.waveformImages
 
 // Selectors mainly pertaining to the information fetched from Opencast
 export const selectVideoURL = (state: { videoState: { videoURLs: video["videoURLs"] } }) => state.videoState.videoURLs


### PR DESCRIPTION
This PR will display pre-generated waveform images sent from the Opencast backend. If none are sent, waveform generation will still kick in like normal.

This requires Opencast workflows to include the "Waveform" operation and add the generated file to the internal publication.

Waveform generation seems to crash the editor for very long video/audio files, so this PR provides a workaround that does not require disabling waveform generation outright.

Also requires https://github.com/opencast/opencast/pull/3780 to be merged.

Probably resolves #501