### PR TITLE
Update release documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The editor can be configured through the `editor-settings.toml` settings file. I
 How to cut a release for Opencast
 ---------------------------------
 
+0. Make sure all merged pull requests have proper `type:` labels. They are used for generating the release notes.
 1. Switch to the commit you want to turn into the release
 2. Create and push a new tag
    ```


### PR DESCRIPTION
This patch updates the documentation about how to create a release to include a step to ensure that pull requests have proper labels since they are used for generating the release notes and pull requests withouts may not be picked up properly.