### PR TITLE
Ensure that the workflow id is set for single workflow

### DIFF
--- a/src/main/WorkflowSelection.tsx
+++ b/src/main/WorkflowSelection.tsx
@@ -113,6 +113,7 @@ const WorkflowSelection : React.FC<{}> = () => {
         )
       );
     } else if (workflows.length === 1) {
+      dispatch(setSelectedWorkflowIndex(workflows[0].id))
       return (
         render(
           t("workflowSelection.saveAndProcess-text"),


### PR DESCRIPTION
Fixes a problem where the workflow id was not sent to Opencast when saving & processing when only a single workflow is available for processing.