### PR TITLE
Avoid calling dispatch on every rerender

### DIFF
--- a/src/main/WorkflowConfiguration.tsx
+++ b/src/main/WorkflowConfiguration.tsx
@@ -79,6 +79,7 @@ export const SaveAndProcessButton: React.FC<{text: string}> = ({text}) => {
   // Let users leave the page without warning after a successful save
   useEffect(() => {
     if (workflowStatus === 'success' && metadataStatus === 'success') {
+      dispatch(setEnd({hasEnded: true, value: 'success'}))
       dispatch(videoSetHasChanges(false))
       dispatch(metadataSetHasChanges(false))
     }
@@ -114,7 +115,6 @@ export const SaveAndProcessButton: React.FC<{text: string}> = ({text}) => {
   } else if (workflowStatus === 'success' && metadataStatus === 'success') {
     icon = faCheck
     spin = false
-    dispatch(setEnd({hasEnded: true, value: 'success'}))
   } else if (workflowStatus === 'loading' || metadataStatus === 'loading') {
     icon = faSpinner
     spin = true

--- a/src/main/WorkflowSelection.tsx
+++ b/src/main/WorkflowSelection.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 
 import { css } from '@emotion/react'
 import { backOrContinueStyle, errorBoxStyle, flexGapReplacementStyle } from '../cssStyles'
@@ -58,6 +58,12 @@ const WorkflowSelection : React.FC<{}> = () => {
     maxHeight: '50vh',
   })
 
+  useEffect(() => {
+    if (workflows.length === 1) {
+      dispatch(setSelectedWorkflowIndex(workflows[0].id))
+    }
+  }, [dispatch, workflows])
+
   const handleWorkflowSelectChange = (event: { target: { value: string}; }) => {
     dispatch(setSelectedWorkflowIndex(event.target.value))
   };
@@ -113,7 +119,6 @@ const WorkflowSelection : React.FC<{}> = () => {
         )
       );
     } else if (workflows.length === 1) {
-      dispatch(setSelectedWorkflowIndex(workflows[0].id))
       return (
         render(
           t("workflowSelection.saveAndProcess-text"),


### PR DESCRIPTION
Some dispatch hooks were placed uncondoditionally, resulting in them being called on every rerender. While that is in and of itself not an issue (redux will easily notice that the repeated dispatches would not change anything and ignores them), it can trigger redux' infinite-loop-prevention hook, causing the website to crash.