### PR TITLE
Specify preview mode behaviour for last segment

### DIFF
--- a/src/redux/videoSlice.ts
+++ b/src/redux/videoSlice.ts
@@ -280,6 +280,19 @@ const skipDeletedSegments = (state: WritableDraft<video>) => {
           endTime = state.segments[index].start + 1
           break
         }
+
+        // If this is the last segment and it is deleted
+        if (index + 1 === state.segments.length) {
+          // Properly pause the player
+          state.isPlaying = false
+          // Jump to start of first non-deleted segment
+          for (let j = 0; j < state.segments.length; j++) {
+            if (!state.segments[j].deleted) {
+              endTime = state.segments[j].start
+              break
+            }
+          }
+        }
       }
 
       state.currentlyAt = endTime


### PR DESCRIPTION
Resolves #740

If the last segment is deleted and preview mode is enabled, the video player now behaves more like you would expect from a video player