### PR TITLE
Thumbnail Editor

### DIFF
--- a/public/editor-settings.toml
+++ b/public/editor-settings.toml
@@ -96,7 +96,19 @@ password = "opencast"
 [thumbnail]
 
 # If the thumbnail editor appears in the main menu
-# Warning: This interface is unfinished
 # Type: boolean
 # Default: false
 show = true
+
+# Whether to use "simple" or "professional" mode.
+# Professional mode allows users to edit all thumbnails that fit the subflavor
+# specified in the Opencast configuration file
+# `etc/org.opencastproject.editor.EditorServiceImpl.cfg`. It is useful
+# when working with multiple thumbnails.
+# Simple mode only allows users to edit the "primary" thumbnail, as specified
+# in the Opencast configuration file
+# `etc/org.opencastproject.editor.EditorServiceImpl.cfg`. It is useful
+# when there is only a single thumbnail to worry about and you want hide
+# potential fallbacks from the user. If a primary thumbnail cannot be
+# determined, this falls back to professional mode.
+simpleMode = false

--- a/public/editor-settings.toml
+++ b/public/editor-settings.toml
@@ -99,4 +99,4 @@ password = "opencast"
 # Warning: This interface is unfinished
 # Type: boolean
 # Default: false
-#show = false
+show = true

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,6 +44,7 @@ interface iSettings {
   },
   thumbnail: {
     show: boolean,
+    simpleMode: boolean,
   }
 }
 
@@ -70,6 +71,7 @@ var defaultSettings: iSettings = {
   },
   thumbnail: {
     show: false,
+    simpleMode: false,
   }
 }
 var configFileSettings: iSettings
@@ -311,6 +313,7 @@ const SCHEMA = {
   },
   thumbnail: {
     show : types.boolean,
+    simpleMode: types.boolean,
   }
 }
 

--- a/src/cssStyles.tsx
+++ b/src/cssStyles.tsx
@@ -132,6 +132,28 @@ export const backOrContinueStyle = css(({
 }))
 
 /**
+ * CSS for a title
+ */
+export const titleStyle = css(({
+  display: 'inline-block',
+  padding: '15px',
+  overflow: 'hidden',
+  whiteSpace: "nowrap",
+  textOverflow: 'ellipsis',
+  maxWidth: '500px',
+}))
+
+/**
+ * Addendum for the titleStyle
+ * Used for page titles
+ */
+export const titleStyleBold = css({
+  fontWeight: 'bold',
+  fontSize: '24px',
+  verticalAlign: '-2.5px',
+})
+
+/**
  * CSS for ariaLive regions that should not be visible
  */
 export const ariaLive = css({

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -165,6 +165,28 @@
       }
     },
 
+    "thumbnail": {
+      "title": "Thumbnail Editor",
+      "noThumbnailAvailable": "No Thumbnail set",
+      "previewImageAlt": "Thumbnail for",
+      "buttonGenerate": "Generate",
+      "buttonGenerate-tooltip": "Create a new thumbnail from the current scrubber position",
+      "buttonGenerate-tooltip-aria": "Create a new thumbnail from the current scrubber position",
+      "buttonUpload": "Upload",
+      "buttonUpload-tooltip": "Upload an image",
+      "buttonUpload-tooltip-aria": "Upload an image",
+      "buttonUseForOtherThumbnails": "Use for other thumbnails",
+      "buttonUseForOtherThumbnails-tooltip": "Use the thumbnail for all other videos",
+      "buttonUseForOtherThumbnails-tooltip-aria": "Use the thumbnail for all other videos",
+      "buttonDiscard": "Discard",
+      "buttonDiscard-tooltip": "Undo all changes made to this thumbnail",
+      "buttonDiscard-tooltip-aria": "Undo all changes made to this thumbnail",
+      "buttonGenerateAll": "Generate All",
+      "buttonGenerateAll-tooltip": "Create new thumbnails from the current scrubber position",
+      "buttonGenerateAll-tooltip-aria": "Create new thumbnails from the current scrubber position",
+      "explanation": "Some explanatory text can go here"
+    },
+
     "error": {
       "generic-message": "A critical error has occurred!",
       "details": "Details: ",

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -184,7 +184,14 @@
       "buttonGenerateAll": "Generate All",
       "buttonGenerateAll-tooltip": "Create new thumbnails from the current scrubber position",
       "buttonGenerateAll-tooltip-aria": "Create new thumbnails from the current scrubber position",
-      "explanation": "Some explanatory text can go here"
+      "explanation": "Here you can set the thumbnail for each video",
+      "primary": "Primary",
+      "secondary": "Secondary"
+    },
+
+    "thumbnailSimple": {
+      "rowTitle": "Change thumbnail here",
+      "from": "from"
     },
 
     "error": {

--- a/src/main/MainContent.tsx
+++ b/src/main/MainContent.tsx
@@ -24,6 +24,7 @@ import { hasChanges as videoHasChanges } from "../redux/videoSlice";
 import { hasChanges as metadataHasChanges} from "../redux/metadataSlice";
 import { selectTheme } from "../redux/themeSlice";
 import ThemeSwitcher from "./ThemeSwitcher";
+import Thumbnail from "./Thumbnail";
 
 /**
  * A container for the main functionality
@@ -82,6 +83,16 @@ const MainContent: React.FC<{}> = () => {
     background: `${theme.background}`,
   })
 
+  const thumbnailSelectStyle = css({
+    ...displayState(MainMenuStateNames.thumbnail),
+    flexDirection: 'column' as const,
+    alignContent: 'space-around',
+    ...(flexGapReplacementStyle(20, false)),
+    paddingRight: '20px',
+    paddingLeft: '161px',
+    background: `${theme.background}`,
+  })
+
   const finishStyle = css({
     ...displayState(MainMenuStateNames.finish),
     flexDirection: 'column' as const,
@@ -122,6 +133,9 @@ const MainContent: React.FC<{}> = () => {
       </div>
       <div css={trackSelectStyle}>
           <TrackSelection />
+      </div>
+      <div css={thumbnailSelectStyle}>
+          <Thumbnail />
       </div>
       <div css={finishStyle}>
         <Finish />

--- a/src/main/MainMenu.tsx
+++ b/src/main/MainMenu.tsx
@@ -135,7 +135,6 @@ const MainMenuButton: React.FC<mainMenuButtonInterface> = ({iconName, stateName,
       backgroundColor: `${theme.menuButton}`,
     },
     flexDirection: 'column' as const,
-    padding: '0px 2px',
   });
 
   const miniMenuButtonStyle = css({

--- a/src/main/MainMenu.tsx
+++ b/src/main/MainMenu.tsx
@@ -135,6 +135,7 @@ const MainMenuButton: React.FC<mainMenuButtonInterface> = ({iconName, stateName,
       backgroundColor: `${theme.menuButton}`,
     },
     flexDirection: 'column' as const,
+    padding: '0px 2px',
   });
 
   const miniMenuButtonStyle = css({

--- a/src/main/Thumbnail.tsx
+++ b/src/main/Thumbnail.tsx
@@ -6,7 +6,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { settings } from "../config";
-import { basicButtonStyle, titleStyle, titleStyleBold } from "../cssStyles";
+import { basicButtonStyle, deactivatedButtonStyle, titleStyle, titleStyleBold } from "../cssStyles";
 import { selectTheme, Theme } from "../redux/themeSlice";
 import { selectOriginalThumbnails, selectTracks, setHasChanges, setThumbnail, setThumbnails } from "../redux/videoSlice";
 import { Track } from "../types";
@@ -290,7 +290,8 @@ const ThumbnailButtons : React.FC<{
 
   return (
     <div css={thumbnailButtonsStyle}>
-      <div css={[basicButtonStyle, thumbnailButtonStyle(theme)]}
+      <div
+        css={thumbnailButtonStyle(true, theme)}
         title={t('thumbnail.buttonGenerate-tooltip')}
         role="button" tabIndex={0} aria-label={t('thumbnail.buttonGenerate-tooltip-aria')}
         onClick={() => {
@@ -302,7 +303,8 @@ const ThumbnailButtons : React.FC<{
       >
         {t('thumbnail.buttonGenerate')}
       </div>
-      <div css={[basicButtonStyle, thumbnailButtonStyle(theme)]}
+      <div
+        css={thumbnailButtonStyle(true, theme)}
         title={t('thumbnail.buttonUpload-tooltip')}
         role="button" tabIndex={0} aria-label={t('thumbnail.buttonUpload-tooltip-aria')}
         onClick={() => {
@@ -323,7 +325,8 @@ const ThumbnailButtons : React.FC<{
           accept="image/*"
           onChange={(event) => uploadCallback(event, track)}
         />
-      <div css={[basicButtonStyle, thumbnailButtonStyle(theme)]}
+      <div
+        css={thumbnailButtonStyle(track.thumbnailUri? track.thumbnailUri.startsWith("data"): false, theme)}
         title={t('thumbnail.buttonUseForOtherThumbnails-tooltip')}
         role="button" tabIndex={0} aria-label={t('thumbnail.buttonUseForOtherThumbnails-tooltip-aria')}
         onClick={() => {
@@ -335,7 +338,8 @@ const ThumbnailButtons : React.FC<{
       >
         {t('thumbnail.buttonUseForOtherThumbnails')}
       </div>
-      <div css={[basicButtonStyle, thumbnailButtonStyle(theme)]}
+      <div
+        css={thumbnailButtonStyle(track.thumbnailUri? track.thumbnailUri.startsWith("data"): false, theme)}
         title={t('thumbnail.buttonDiscard-tooltip')}
         role="button" tabIndex={0} aria-label={t('thumbnail.buttonDiscard-tooltip-aria')}
         onClick={() => {
@@ -467,7 +471,8 @@ const ThumbnailButtonsSimple : React.FC<{
   return (
     <div css={thumbnailButtonsStyle}>
       {tracks.map( (generateTrack: Track, generateIndex: number) => (
-        <div css={[basicButtonStyle, thumbnailButtonStyle(theme)]}
+        <div
+          css={thumbnailButtonStyle(true, theme)}
           title={t('thumbnail.buttonGenerate-tooltip')}
           role="button" tabIndex={0} aria-label={t('thumbnail.buttonGenerate-tooltip-aria')}
           onClick={() => {
@@ -480,7 +485,8 @@ const ThumbnailButtonsSimple : React.FC<{
           {t('thumbnail.buttonGenerate') + " " + t("thumbnailSimple.from") + " " + generateTrack.flavor.type}
         </div>
       ))}
-      <div css={[basicButtonStyle, thumbnailButtonStyle(theme)]}
+      <div
+        css={thumbnailButtonStyle(true, theme)}
         title={t('thumbnail.buttonUpload-tooltip')}
         role="button" tabIndex={0} aria-label={t('thumbnail.buttonUpload-tooltip-aria')}
         onClick={() => {
@@ -501,7 +507,8 @@ const ThumbnailButtonsSimple : React.FC<{
           accept="image/*"
           onChange={(event) => uploadCallback(event, track)}
         />
-      <div css={[basicButtonStyle, thumbnailButtonStyle(theme)]}
+      <div
+        css={thumbnailButtonStyle(track.thumbnailUri? track.thumbnailUri.startsWith("data"): false, theme)}
         title={t('thumbnail.buttonDiscard-tooltip')}
         role="button" tabIndex={0} aria-label={t('thumbnail.buttonDiscard-tooltip-aria')}
         onClick={() => {
@@ -551,15 +558,18 @@ const thumbnailButtonsStyle = css({
   gap: '20px'
 })
 
-const thumbnailButtonStyle = (theme: Theme) => css({
-  maxWidth: '75%',
-  maxHeight: '75%',
-  boxShadow: `${theme.boxShadow}`,
-  background: `${theme.element_bg}`,
-  justifySelf: 'center',
-  alignSelf: 'center',
-  padding: '20px'
-})
+const thumbnailButtonStyle = (active: boolean, theme: Theme) => [
+  active ? basicButtonStyle : deactivatedButtonStyle,
+  {
+    maxWidth: '75%',
+    maxHeight: '75%',
+    boxShadow: `${theme.boxShadow}`,
+    background: `${theme.element_bg}`,
+    justifySelf: 'center',
+    alignSelf: 'center',
+    padding: '20px'
+  }
+];
 
 
 export default Thumbnail;

--- a/src/main/Thumbnail.tsx
+++ b/src/main/Thumbnail.tsx
@@ -117,6 +117,7 @@ const ThumbnailTable : React.FC<{
     display: 'flex',
     flexDirection: 'column',
     ...(flexGapReplacementStyle(10, false)),
+    paddingBottom: '10px',
   })
 
   const renderSingleOrMultiple = () => {

--- a/src/main/Thumbnail.tsx
+++ b/src/main/Thumbnail.tsx
@@ -1,0 +1,176 @@
+import { css } from "@emotion/react";
+import React from "react";
+import { useSelector } from "react-redux";
+import { basicButtonStyle } from "../cssStyles";
+import { selectTheme, Theme } from "../redux/themeSlice";
+import { selectTracks } from "../redux/videoSlice";
+import { Track } from "../types";
+import Timeline from "./Timeline";
+import { VideoControls, VideoPlayer } from "./Video";
+
+
+/**
+ * Displays a menu for selecting what should be done with the current changes
+ */
+const Thumbnail : React.FC<{}> = () => {
+
+  const thumbnailStyle = css({
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  })
+
+  const titleStyle = css({
+    display: 'inline-block',
+    padding: '15px',
+    overflow: 'hidden',
+    whiteSpace: "nowrap",
+    textOverflow: 'ellipsis',
+    maxWidth: '500px',
+    justifySelf: 'center'
+  })
+
+  const titleStyleBold = css({
+    fontWeight: 'bold',
+    fontSize: '24px',
+    verticalAlign: '-2.5px',
+  })
+
+  const videoContainerStyle = css({
+    width: '100%',
+  })
+
+  return (
+    <div css={thumbnailStyle}>
+      <div css={[titleStyle, titleStyleBold]}>Thumbnail Editor</div>
+      <div css={videoContainerStyle}>
+        <ThumbnailTable />
+        <GenerateAllRow />
+        <VideoControls />
+        <Timeline></Timeline>
+      </div>
+    </div>
+  );
+}
+
+const ThumbnailTable : React.FC<{}> = () => {
+
+  const tracks = useSelector(selectTracks)
+  const theme = useSelector(selectTheme);
+
+  const thumbnailTableStyle = css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '10px',
+  })
+
+  const rowTitleStyle = css({
+    textAlign: 'left',
+    textTransform: 'capitalize',
+    fontSize: 'larger',
+    fontWeight: 'bold',
+  })
+
+  const thumbnailRowStyle = css({
+    display: 'flex',
+    flexDirection: 'row',
+    width: '100%',
+    height: '200px',
+    justifyContent: 'center',
+  })
+
+  const cellVideo = css({
+    flex: 8,
+    width: '100%',
+    height: '100%',
+  })
+
+  const cellThumbnail = css({
+    display: 'flex',
+    flex: 8,
+    justifyContent: 'center',
+    alignItems: 'center',
+  })
+
+  const imageStyle = css({
+    maxWidth: '100%',
+    maxHeight: '100%',
+    minWidth: '100px'
+  })
+
+  const cellButtons = css({
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    flex: 4,
+    gap: '20px'
+  })
+
+  const buttonsStyle = (theme: Theme) => css({
+    maxWidth: '75%',
+    maxHeight: '75%',
+    boxShadow: `${theme.boxShadow}`,
+    background: `${theme.element_bg}`,
+    justifySelf: 'center',
+    alignSelf: 'center',
+    padding: '20px'
+  })
+
+  return(
+    <div css={thumbnailTableStyle}>
+      {tracks.map( (track: Track, index: number) => (
+        <div>
+          <div css={rowTitleStyle}>{track.flavor.type}</div>
+          <div css={thumbnailRowStyle} key={index}>
+            <div css={cellVideo}>
+              <VideoPlayer dataKey={index} url={track.uri} isPrimary={index === 0 ? true : false}/>
+            </div>
+            <div css={cellThumbnail}>
+              <img src="https://upload.wikimedia.org/wikipedia/commons/a/a1/RedBananasMetepec.JPG"
+                alt="Banana"
+                css={imageStyle}></img>
+            </div>
+            <div css={cellButtons}>
+              <div css={[basicButtonStyle, buttonsStyle(theme)]}>Generate</div>
+              <div css={[basicButtonStyle, buttonsStyle(theme)]}>Upload</div>
+              <div css={[basicButtonStyle, buttonsStyle(theme)]}>Use for other thumbnails</div>
+              <div css={[basicButtonStyle, buttonsStyle(theme)]}>Discard</div>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+const GenerateAllRow : React.FC<{}> = () => {
+
+  const theme = useSelector(selectTheme);
+
+  const rowStyle = css({
+    display: 'flex',
+    flexDirection: 'row',
+    width: '100%',
+    height: '50px',
+    padding: '20px',
+    gap: '20px',
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderBottom: `${theme.menuBorder}`,
+  })
+
+  const buttonStyle = css({
+    height: '100%',
+    minWidth: '200px',
+    boxShadow: `${theme.boxShadow}`,
+    background: `${theme.element_bg}`,
+  })
+
+  return (
+    <div css={rowStyle}>
+      <div>Some explanatory text or something</div>
+      <div css={[basicButtonStyle, buttonStyle]}>Generate All</div>
+    </div>
+  )
+}
+
+export default Thumbnail;

--- a/src/main/Thumbnail.tsx
+++ b/src/main/Thumbnail.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/react";
-import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
+import { faCamera, faCopy, faInfoCircle, faTimesCircle, faUpload } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { t } from "i18next";
 import React from "react";
@@ -303,6 +303,7 @@ const ThumbnailButtons : React.FC<{
           generate(track, index)
         }}}
       >
+        <FontAwesomeIcon icon={faCamera}/>
         {t('thumbnail.buttonGenerate')}
       </div>
       <div
@@ -316,6 +317,7 @@ const ThumbnailButtons : React.FC<{
           upload(index)
         }}}
       >
+        <FontAwesomeIcon icon={faUpload}/>
         {t('thumbnail.buttonUpload')}
       </div>
         <input
@@ -338,6 +340,7 @@ const ThumbnailButtons : React.FC<{
           setForOtherThumbnails(track.thumbnailUri)
         }}}
       >
+        <FontAwesomeIcon icon={faCopy}/>
         {t('thumbnail.buttonUseForOtherThumbnails')}
       </div>
       <div
@@ -351,6 +354,7 @@ const ThumbnailButtons : React.FC<{
           discard(track.id)
         }}}
       >
+        <FontAwesomeIcon icon={faTimesCircle}/>
         {t('thumbnail.buttonDiscard')}
       </div>
     </div>
@@ -408,6 +412,7 @@ const AffectAllRow : React.FC<{
           generateAll()
         }}}
       >
+        <FontAwesomeIcon icon={faCamera}/>
         {t('thumbnail.buttonGenerateAll')}
       </div>
     </div>

--- a/src/main/Thumbnail.tsx
+++ b/src/main/Thumbnail.tsx
@@ -533,7 +533,7 @@ const thumbnailTableRowStyle = css({
   border: '1px solid grey',
   backgroundColor: 'lightgrey',
   height: '240px',
-  padding: '6px',
+  padding: '6px 10px',
 })
 
 const thumbnailTableRowTitleStyle = css({
@@ -555,19 +555,19 @@ const thumbnailTableRowRowStyle = css({
 const thumbnailButtonsStyle = css({
   display: 'grid',
   gridTemplateColumns: '1fr 1fr',
-  gap: '20px'
+  gridGap: '30px'
 })
 
 const thumbnailButtonStyle = (active: boolean, theme: Theme) => [
   active ? basicButtonStyle : deactivatedButtonStyle,
   {
-    maxWidth: '75%',
-    maxHeight: '75%',
+    width: '100%',
+    height: '100%',
     boxShadow: `${theme.boxShadow}`,
     background: `${theme.element_bg}`,
     justifySelf: 'center',
     alignSelf: 'center',
-    padding: '20px'
+    padding: '0px 2px'
   }
 ];
 

--- a/src/main/Thumbnail.tsx
+++ b/src/main/Thumbnail.tsx
@@ -115,9 +115,10 @@ const ThumbnailTable : React.FC<{
 
   const thumbnailTableStyle = css({
     display: 'flex',
-    flexDirection: 'column',
+    flexDirection: 'row' as const,
+    justifyContent: 'space-around',
+    flexWrap: 'wrap',
     ...(flexGapReplacementStyle(10, false)),
-    paddingBottom: '10px',
   })
 
   const renderSingleOrMultiple = () => {

--- a/src/main/Thumbnail.tsx
+++ b/src/main/Thumbnail.tsx
@@ -444,6 +444,7 @@ const ThumbnailTableSingleRow: React.FC<{
       <div css={thumbnailTableRowTitleStyle}>
         {t("thumbnailSimple.rowTitle")}
       </div>
+      <hr css={{width: '100%'}}></hr>
       <div css={thumbnailTableRowRowStyle} key={index}>
         <ThumbnailDisplayer track={track} />
         <ThumbnailButtonsSimple
@@ -491,6 +492,7 @@ const ThumbnailButtonsSimple : React.FC<{
             generate(track, generateIndex)
           }}}
         >
+          <FontAwesomeIcon icon={faCamera}/>
           {t('thumbnail.buttonGenerate') + " " + t("thumbnailSimple.from") + " " + generateTrack.flavor.type}
         </div>
       ))}
@@ -505,6 +507,7 @@ const ThumbnailButtonsSimple : React.FC<{
           upload(index)
         }}}
       >
+        <FontAwesomeIcon icon={faUpload}/>
         {t('thumbnail.buttonUpload')}
       </div>
         <input
@@ -527,6 +530,7 @@ const ThumbnailButtonsSimple : React.FC<{
           discard(track.id)
         }}}
       >
+        <FontAwesomeIcon icon={faTimesCircle}/>
         {t('thumbnail.buttonDiscard')}
       </div>
     </div>

--- a/src/main/Thumbnail.tsx
+++ b/src/main/Thumbnail.tsx
@@ -224,13 +224,12 @@ const ThumbnailDisplayer : React.FC<{track: Track}> = ({track}) => {
   const imageStyle = css({
     maxWidth: '100%',
     maxHeight: '100%',
-    minWidth: '100px',
+    objectFit: 'contain',
   })
 
   const placeholderStyle = css({
     maxWidth: '100%',
     maxHeight: '100%',
-    minWidth: '100px',
     display: 'flex',
     backgroundColor: 'grey',
     justifyContent: 'center',

--- a/src/main/Thumbnail.tsx
+++ b/src/main/Thumbnail.tsx
@@ -217,18 +217,11 @@ const ThumbnailDisplayer : React.FC<{track: Track}> = ({track}) => {
 
   const { t } = useTranslation()
 
-  const cellThumbnail = css({
-    display: 'flex',
-  })
-
   const imageStyle = css({
-    maxWidth: '100%',
     maxHeight: '100%',
-    objectFit: 'contain',
   })
 
   const placeholderStyle = css({
-    maxWidth: '100%',
     maxHeight: '100%',
     display: 'flex',
     backgroundColor: 'grey',
@@ -238,7 +231,7 @@ const ThumbnailDisplayer : React.FC<{track: Track}> = ({track}) => {
   })
 
   return (
-    <div css={cellThumbnail}>
+    <>
       {(track.thumbnailUri !== null && track.thumbnailUri !== undefined) ?
         // Thumbnail image
         <img src={track.thumbnailUri}
@@ -251,7 +244,7 @@ const ThumbnailDisplayer : React.FC<{track: Track}> = ({track}) => {
           <span>{t('thumbnail.noThumbnailAvailable')}</span>
         </div>
       }
-    </div>
+    </>
   )
 }
 

--- a/src/main/Thumbnail.tsx
+++ b/src/main/Thumbnail.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { basicButtonStyle } from "../cssStyles";
 import { selectTheme, Theme } from "../redux/themeSlice";
-import { selectThumbnails, selectTracks, setThumbnail, setThumbnails } from "../redux/videoSlice";
+import { removeThumbnail, selectThumbnails, selectTracks, setThumbnail, setThumbnails } from "../redux/videoSlice";
 import { Track } from "../types";
 import Timeline from "./Timeline";
 import { VideoControls, VideoPlayer } from "./Video";
@@ -114,6 +114,10 @@ const ThumbnailTable : React.FC<{}> = () => {
       changedThumbnails.push({videoId: track.id, flavor: {type: track.flavor.type, subtype: flavorSubtype}, uri: uri})
     }
     dispatch(setThumbnails(changedThumbnails))
+  }
+
+  const discardThumbnail = (id: string) => {
+    dispatch(removeThumbnail(id))
   }
 
   const thumbnailTableStyle = css({
@@ -228,7 +232,9 @@ const ThumbnailTable : React.FC<{}> = () => {
               <div css={[basicButtonStyle, buttonsStyle(theme)]} onClick={() => {
                   setForOtherThumbnails(thumbnails.find(t => t.videoId === track.id)?.uri)
                 }}>Use for other thumbnails</div>
-              <div css={[basicButtonStyle, buttonsStyle(theme)]}>Discard</div>
+              <div css={[basicButtonStyle, buttonsStyle(theme)]} onClick={() => {
+                  discardThumbnail(track.id)
+                }}>Discard</div>
             </div>
 
           </div>

--- a/src/main/Thumbnail.tsx
+++ b/src/main/Thumbnail.tsx
@@ -319,6 +319,7 @@ const ThumbnailButtons : React.FC<{
           type="file"
           accept="image/*"
           onChange={(event) => uploadCallback(event, track)}
+          aria-hidden="true"
         />
       <ThumbnailButton
         handler={() => { setForOtherThumbnails(track.thumbnailUri) }}
@@ -518,6 +519,7 @@ const ThumbnailButtonsSimple : React.FC<{
           type="file"
           accept="image/*"
           onChange={(event) => uploadCallback(event, track)}
+          aria-hidden="true"
         />
       <ThumbnailButton
         handler={() => { discard(track.id) }}

--- a/src/main/Thumbnail.tsx
+++ b/src/main/Thumbnail.tsx
@@ -222,6 +222,7 @@ const ThumbnailDisplayer : React.FC<{track: Track}> = ({track}) => {
 
   const imageStyle = css({
     maxHeight: '100%',
+    height: '280px',
   })
 
   const placeholderStyle = css({
@@ -531,7 +532,6 @@ const ThumbnailButtonsSimple : React.FC<{
 const thumbnailTableRowStyle = css({
   display: 'flex',
   flexDirection: 'column',
-  height: '240px',
   padding: '6px 12px',
 })
 
@@ -545,15 +545,21 @@ const thumbnailTableRowTitleStyle = css({
 const thumbnailTableRowRowStyle = css({
   display: 'flex',
   flexDirection: 'row',
-  height: '200px',
-  justifyContent: 'center',
   ...(flexGapReplacementStyle(20, true)),
+
+  justifyContent: 'space-around',
+  flexWrap: 'wrap',
 })
 
 const thumbnailButtonsStyle = css({
-  display: 'grid',
-  gridTemplateColumns: '1fr 1fr',
-  gridGap: '30px'
+  // TODO: Avoid hard-coding max-width
+  "@media (max-width: 1000px)": {
+    flexDirection: 'row',
+    width: '100%',
+  },
+  display: 'flex',
+  flexDirection: 'column',
+  ...(flexGapReplacementStyle(20, true)),
 })
 
 const thumbnailButtonStyle = (active: boolean, theme: Theme) => [

--- a/src/main/Thumbnail.tsx
+++ b/src/main/Thumbnail.tsx
@@ -6,7 +6,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { settings } from "../config";
-import { basicButtonStyle, deactivatedButtonStyle, titleStyle, titleStyleBold } from "../cssStyles";
+import { basicButtonStyle, deactivatedButtonStyle, flexGapReplacementStyle, titleStyle, titleStyleBold } from "../cssStyles";
 import { selectTheme, Theme } from "../redux/themeSlice";
 import { selectOriginalThumbnails, selectTracks, setHasChanges, setThumbnail, setThumbnails } from "../redux/videoSlice";
 import { Track } from "../types";
@@ -116,7 +116,7 @@ const ThumbnailTable : React.FC<{
   const thumbnailTableStyle = css({
     display: 'flex',
     flexDirection: 'column',
-    gap: '10px',
+    ...(flexGapReplacementStyle(10, false)),
   })
 
   const renderSingleOrMultiple = () => {
@@ -533,7 +533,7 @@ const thumbnailTableRowStyle = css({
   border: '1px solid grey',
   backgroundColor: 'lightgrey',
   height: '240px',
-  padding: '6px 10px',
+  padding: '6px 12px',
 })
 
 const thumbnailTableRowTitleStyle = css({
@@ -549,7 +549,7 @@ const thumbnailTableRowRowStyle = css({
   flexDirection: 'row',
   height: '200px',
   justifyContent: 'center',
-  gap: '20px',
+  ...(flexGapReplacementStyle(20, true)),
 })
 
 const thumbnailButtonsStyle = css({

--- a/src/main/Thumbnail.tsx
+++ b/src/main/Thumbnail.tsx
@@ -220,17 +220,19 @@ const ThumbnailDisplayer : React.FC<{track: Track}> = ({track}) => {
 
   const { t } = useTranslation()
 
+  const generalStyle = css({
+    height: '280px',
+  })
+
   const imageStyle = css({
     maxHeight: '100%',
-    height: '280px',
   })
 
   const placeholderStyle = css({
     backgroundColor: 'grey',
     // For whatever reason, setting the width relative to height is way to difficult,
     // so we hardcode the box size here
-    height: '200px',
-    width: '355px',
+    width: '497px',
     // Support for aspectRatio is still spotty and implementations across browsers
     // differ too much
     // aspectRatio: '16/9',
@@ -246,11 +248,11 @@ const ThumbnailDisplayer : React.FC<{track: Track}> = ({track}) => {
         // Thumbnail image
         <img src={track.thumbnailUri}
           alt={t('thumbnail.previewImageAlt') + ": " + track.flavor.type}
-          css={imageStyle}
+          css={[generalStyle, imageStyle]}
         />
         :
         // Placeholder
-        <div css={placeholderStyle}>
+        <div css={[generalStyle, placeholderStyle]}>
           <span>{t('thumbnail.noThumbnailAvailable')}</span>
         </div>
       }

--- a/src/main/Thumbnail.tsx
+++ b/src/main/Thumbnail.tsx
@@ -223,12 +223,18 @@ const ThumbnailDisplayer : React.FC<{track: Track}> = ({track}) => {
   })
 
   const placeholderStyle = css({
-    maxHeight: '100%',
-    display: 'flex',
     backgroundColor: 'grey',
+    // For whatever reason, setting the width relative to height is way to difficult,
+    // so we hardcode the box size here
+    height: '200px',
+    width: '355px',
+    // Support for aspectRatio is still spotty and implementations across browsers
+    // differ too much
+    // aspectRatio: '16/9',
+
+    display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
-    aspectRatio: '16/9',
   })
 
   return (

--- a/src/main/Thumbnail.tsx
+++ b/src/main/Thumbnail.tsx
@@ -195,6 +195,7 @@ const ThumbnailTableRow: React.FC<{
       <div css={thumbnailTableRowTitleStyle}>
         {track.flavor.type + renderPriority(track.thumbnailPriority)}
       </div>
+      <hr css={{width: '100%'}}></hr>
       <div css={thumbnailTableRowRowStyle} key={index}>
         <ThumbnailDisplayer track={track} />
         <ThumbnailButtons
@@ -529,8 +530,6 @@ const ThumbnailButtonsSimple : React.FC<{
 const thumbnailTableRowStyle = css({
   display: 'flex',
   flexDirection: 'column',
-  border: '1px solid grey',
-  backgroundColor: 'lightgrey',
   height: '240px',
   padding: '6px 12px',
 })
@@ -540,7 +539,6 @@ const thumbnailTableRowTitleStyle = css({
   textTransform: 'capitalize',
   fontSize: 'larger',
   fontWeight: 'bold',
-  color: 'black',   // Override dark mode color invert
 })
 
 const thumbnailTableRowRowStyle = css({

--- a/src/main/Thumbnail.tsx
+++ b/src/main/Thumbnail.tsx
@@ -500,6 +500,7 @@ const ThumbnailButtonsSimple : React.FC<{
           ariaLabel={t('thumbnail.buttonGenerate-tooltip-aria')}
           icon={faCamera}
           active={true}
+          key={generateIndex}
         />
       ))}
       <ThumbnailButton

--- a/src/main/Thumbnail.tsx
+++ b/src/main/Thumbnail.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { basicButtonStyle } from "../cssStyles";
 import { selectTheme, Theme } from "../redux/themeSlice";
-import { selectThumbnails, selectTracks, setThumbnail } from "../redux/videoSlice";
+import { selectThumbnails, selectTracks, setThumbnail, setThumbnails } from "../redux/videoSlice";
 import { Track } from "../types";
 import Timeline from "./Timeline";
 import { VideoControls, VideoPlayer } from "./Video";
@@ -104,6 +104,17 @@ const ThumbnailTable : React.FC<{}> = () => {
      }
      reader.readAsDataURL(fileObj);
   };
+
+  const setForOtherThumbnails = (uri: string | undefined) => {
+    if (uri === undefined) {
+      return
+    }
+    const changedThumbnails = []
+    for (const track of tracks) {
+      changedThumbnails.push({videoId: track.id, flavor: {type: track.flavor.type, subtype: flavorSubtype}, uri: uri})
+    }
+    dispatch(setThumbnails(changedThumbnails))
+  }
 
   const thumbnailTableStyle = css({
     display: 'flex',
@@ -214,7 +225,9 @@ const ThumbnailTable : React.FC<{}> = () => {
                   accept="image/*"
                   onChange={(event) => handleFileChange(event, track)}
                 />
-              <div css={[basicButtonStyle, buttonsStyle(theme)]}>Use for other thumbnails</div>
+              <div css={[basicButtonStyle, buttonsStyle(theme)]} onClick={() => {
+                  setForOtherThumbnails(thumbnails.find(t => t.videoId === track.id)?.uri)
+                }}>Use for other thumbnails</div>
               <div css={[basicButtonStyle, buttonsStyle(theme)]}>Discard</div>
             </div>
 

--- a/src/main/Timeline.tsx
+++ b/src/main/Timeline.tsx
@@ -32,7 +32,7 @@ import { selectTheme } from '../redux/themeSlice';
  * Its width corresponds to the duration of the video
  * TODO: Figure out why ResizeObserver does not update anymore if we stop passing the width to the SegmentsList
  */
-const Timeline: React.FC<{}> = () => {
+const Timeline: React.FC<{timelineHeight?: number}> = ({timelineHeight = 250}) => {
 
   // Init redux variables
   const dispatch = useDispatch();
@@ -42,7 +42,7 @@ const Timeline: React.FC<{}> = () => {
 
   const timelineStyle = css({
     position: 'relative',     // Need to set position for Draggable bounds to work
-    height: '250px',
+    height: timelineHeight + 'px',
     width: '100%',
   });
 
@@ -56,10 +56,10 @@ const Timeline: React.FC<{}> = () => {
 
   return (
   <div ref={ref} css={timelineStyle} title="Timeline" onMouseDown={e => setCurrentlyAtToClick(e)}>
-    <Scrubber timelineWidth={width}/>
-    <div css={{height: '230px'}} >
-      <Waveforms />
-      <SegmentsList timelineWidth={width}/>
+    <Scrubber timelineWidth={width} timelineHeight={timelineHeight}/>
+    <div css={{height: timelineHeight - 20 + 'px'}} >
+      <Waveforms timelineHeight={timelineHeight}/>
+      <SegmentsList timelineWidth={width} timelineHeight={timelineHeight}/>
     </div>
   </div>
   );
@@ -69,7 +69,7 @@ const Timeline: React.FC<{}> = () => {
  * Displays and defines the current position in the video
  * @param param0
  */
-const Scrubber: React.FC<{timelineWidth: number}> = ({timelineWidth}) => {
+const Scrubber: React.FC<{timelineWidth: number, timelineHeight: number}> = ({timelineWidth, timelineHeight}) => {
 
   const { t } = useTranslation();
 
@@ -156,7 +156,7 @@ const Scrubber: React.FC<{timelineWidth: number}> = ({timelineWidth}) => {
 
   const scrubberStyle = css({
     backgroundColor: `${theme.text}`,
-    height: '240px',
+    height: timelineHeight - 10 + 'px',
     width: '1px',
     position: 'absolute' as 'absolute',
     zIndex: 2,
@@ -244,7 +244,7 @@ const Scrubber: React.FC<{timelineWidth: number}> = ({timelineWidth}) => {
 /**
  * Container responsible for rendering the segments that are created when cutting
  */
-const SegmentsList: React.FC<{timelineWidth: number}> = ({timelineWidth}) => {
+const SegmentsList: React.FC<{timelineWidth: number, timelineHeight: number}> = ({timelineWidth, timelineHeight}) => {
 
   const { t } = useTranslation();
 
@@ -298,7 +298,7 @@ const SegmentsList: React.FC<{timelineWidth: number}> = ({timelineWidth}) => {
           borderWidth: '1px',
           boxSizing: 'border-box',
           width: ((segment.end - segment.start) / duration) * 100 + '%',
-          height: '230px',
+          height: timelineHeight - 20 + 'px',
           zIndex: 1,
         }}>
         </div>
@@ -322,7 +322,7 @@ const SegmentsList: React.FC<{timelineWidth: number}> = ({timelineWidth}) => {
 /**
  * Generates waveform images and displays them
  */
-const Waveforms: React.FC<{}> = () => {
+const Waveforms: React.FC<{timelineHeight: number}> = ({timelineHeight}) => {
 
   const { t } = useTranslation();
 
@@ -342,7 +342,7 @@ const Waveforms: React.FC<{}> = () => {
     justifyContent: 'center',
     ...(images.length <= 0) && {alignItems: 'center'},  // Only center during loading
     width: '100%',
-    height: '230px',
+    height: timelineHeight - 20 + 'px',
     paddingTop: '10px',
     filter: `${theme.invert_wave}`,
     color: `${theme.inverted_text}`,

--- a/src/main/Video.tsx
+++ b/src/main/Video.tsx
@@ -41,8 +41,6 @@ const Video: React.FC<{}> = () => {
 
   // Init redux variables
   const dispatch = useDispatch()
-  const videoURLs = useSelector(selectVideoURL)
-  const videoCount = useSelector(selectVideoCount)
   const videoURLStatus = useSelector((state: { videoState: { status: httpRequestState["status"] } }) => state.videoState.status);
   const error = useSelector((state: { videoState: { error: httpRequestState["error"] } }) => state.videoState.error)
   const theme = useSelector(selectTheme);
@@ -71,13 +69,6 @@ const Video: React.FC<{}> = () => {
   //   content = <div>{error}</div>
   // }
 
-  // Initialize video players
-  const videoPlayers: JSX.Element[] = [];
-  for (let i = 0; i < videoCount; i++) {
-    // videoPlayers.push(<VideoPlayer key={i} url='https://media.geeksforgeeks.org/wp-content/uploads/20190616234019/Canvas.move_.mp4' />);
-    videoPlayers.push(<VideoPlayer key={i} dataKey={i} url={videoURLs[i]} isPrimary={i === 0}/>);
-  }
-
   // Style
   const videoAreaStyle = css({
     display: 'flex',
@@ -89,6 +80,20 @@ const Video: React.FC<{}> = () => {
     borderBottom: `${theme.menuBorder}`,
   });
 
+  return (
+    <div css={videoAreaStyle}>
+      <VideoHeader />
+      <VideoPlayers />
+      <VideoControls />
+    </div>
+  );
+};
+
+const VideoPlayers: React.FC<{}> = () => {
+
+  const videoURLs = useSelector(selectVideoURL)
+  const videoCount = useSelector(selectVideoCount)
+
   const videoPlayerAreaStyle = css({
     display: 'flex',
     flexDirection: 'row' as const,
@@ -97,23 +102,26 @@ const Video: React.FC<{}> = () => {
     width: '100%',
   });
 
+  // Initialize video players
+  const videoPlayers: JSX.Element[] = [];
+  for (let i = 0; i < videoCount; i++) {
+    // videoPlayers.push(<VideoPlayer key={i} url='https://media.geeksforgeeks.org/wp-content/uploads/20190616234019/Canvas.move_.mp4' />);
+    videoPlayers.push(<VideoPlayer key={i} dataKey={i} url={videoURLs[i]} isPrimary={i === 0}/>);
+  }
+
   return (
-    <div css={videoAreaStyle}>
-      <VideoHeader />
-      <div css={videoPlayerAreaStyle}>
-        {videoPlayers}
-      </div>
-      <VideoControls />
+    <div css={videoPlayerAreaStyle}>
+      {videoPlayers}
     </div>
   );
-};
+}
 
 /**
  * A single video player
  * @param {string} url - URL to load video from
  * @param {boolean} isPrimary - If the player is the main control
  */
-const VideoPlayer: React.FC<{dataKey: number, url: string, isPrimary: boolean}> = ({dataKey, url, isPrimary}) => {
+export const VideoPlayer: React.FC<{dataKey: number, url: string, isPrimary: boolean}> = ({dataKey, url, isPrimary}) => {
 
   const { t } = useTranslation();
 
@@ -267,7 +275,7 @@ const VideoPlayer: React.FC<{dataKey: number, url: string, isPrimary: boolean}> 
  * Contains controls for manipulating multiple video players at once
  * Flexbox magic keeps the play button at the center
  */
-const VideoControls: React.FC<{}> = () => {
+export const VideoControls: React.FC<{}> = () => {
 
   const { t } = useTranslation();
 

--- a/src/main/Video.tsx
+++ b/src/main/Video.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useRef, useEffect, useImperativeHandle } from "react";
 
 import { css } from '@emotion/react'
 
@@ -121,7 +121,9 @@ const VideoPlayers: React.FC<{}> = () => {
  * @param {string} url - URL to load video from
  * @param {boolean} isPrimary - If the player is the main control
  */
-export const VideoPlayer: React.FC<{dataKey: number, url: string, isPrimary: boolean}> = ({dataKey, url, isPrimary}) => {
+export const VideoPlayer = React.forwardRef(
+  (props: {dataKey: number, url: string, isPrimary: boolean}, forwardRefThing) => {
+  const {dataKey, url, isPrimary } = props
 
   const { t } = useTranslation();
 
@@ -204,6 +206,23 @@ export const VideoPlayer: React.FC<{dataKey: number, url: string, isPrimary: boo
     file: { attributes: { tabIndex: '-1' }}
   }
 
+  // External functions
+  useImperativeHandle(forwardRefThing, () => ({
+    // Renders the current frame in the video element to a canvas
+    // Returns the data url
+    captureVideo() {
+      const video = ref.current?.getInternalPlayer() as HTMLVideoElement
+      var canvas = document.createElement("canvas");
+      canvas.width = video.videoWidth;
+      canvas.height = video.videoHeight;
+      var canvasContext = canvas.getContext("2d");
+      if (canvasContext !== null) {
+        canvasContext.drawImage(video, 0, 0);
+        return canvas.toDataURL('image/png')
+      }
+    }
+  }));
+
   const errorBoxStyle = css({
     ...(!errorState) && {display: "none"},
     borderColor: `${theme.error}`,
@@ -269,7 +288,7 @@ export const VideoPlayer: React.FC<{dataKey: number, url: string, isPrimary: boo
   //     </video>
   //   </div>
   // );
-};
+});
 
 /**
  * Contains controls for manipulating multiple video players at once

--- a/src/main/Video.tsx
+++ b/src/main/Video.tsx
@@ -219,7 +219,10 @@ export const VideoPlayer = React.forwardRef(
 
   // Skip player when navigating page with keyboard
   const playerConfig: Config = {
-    file: { attributes: { tabIndex: '-1' }}
+    file: { attributes: {
+      tabIndex: '-1',             // don't tab navigate onto the video
+      crossOrigin: "anonymous"    // allow thumbnail generation
+    }}
   }
 
   // External functions

--- a/src/main/Video.tsx
+++ b/src/main/Video.tsx
@@ -17,7 +17,7 @@ import {
 import ReactPlayer, { Config } from 'react-player'
 
 import { roundToDecimalPlace, convertMsToReadableString } from '../util/utilityFunctions'
-import { basicButtonStyle, flexGapReplacementStyle } from "../cssStyles";
+import { basicButtonStyle, flexGapReplacementStyle, titleStyle, titleStyleBold } from "../cssStyles";
 
 import { GlobalHotKeys } from 'react-hotkeys';
 import { selectMainMenuState } from "../redux/mainMenuSlice";
@@ -475,21 +475,6 @@ const VideoHeader: React.FC<{}> = () => {
   const title = useSelector(selectTitle)
   const metadataTitle = useSelector(selectTitleFromEpisodeDc)
   const presenters = useSelector(selectPresenters)
-
-  const titleStyle = css({
-    display: 'inline-block',
-    padding: '15px',
-    overflow: 'hidden',
-    whiteSpace: "nowrap",
-    textOverflow: 'ellipsis',
-    maxWidth: '500px',
-  })
-
-  const titleStyleBold = css({
-    fontWeight: 'bold',
-    fontSize: '24px',
-    verticalAlign: '-2.5px',
-  })
 
   let presenter_header;
   if (presenters && presenters.length) {

--- a/src/redux/videoSlice.ts
+++ b/src/redux/videoSlice.ts
@@ -208,7 +208,7 @@ const videoSlice = createSlice({
           state.errorReason = 'workflowActive'
           state.error = "An Opencast workflow is currently running, please wait until it is finished."
         }
-        state.tracks = action.payload.tracks
+        state.tracks = action.payload.tracks.sort((a: { thumbnailPriority: number; },b: { thumbnailPriority: number; }) => a.thumbnailPriority - b.thumbnailPriority)
         const videos = state.tracks.filter((track: Track) => track.video_stream.available === true)
         // eslint-disable-next-line no-sequences
         state.videoURLs = videos.reduce((a: string[], o: { uri: string }) => (a.push(o.uri), a), [])

--- a/src/redux/videoSlice.ts
+++ b/src/redux/videoSlice.ts
@@ -1,7 +1,7 @@
 import { createSlice, nanoid, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit'
 import { client } from '../util/client'
 
-import { Segment, httpRequestState, Track, Workflow }  from '../types'
+import { Segment, httpRequestState, Track, Workflow, Thumbnail }  from '../types'
 import { roundToDecimalPlace } from '../util/utilityFunctions'
 import { WritableDraft } from 'immer/dist/internal';
 import { settings } from '../config';
@@ -26,6 +26,7 @@ export interface video {
   title: string,
   presenters: string[],
   workflows: Workflow[],
+  thumbnails: Thumbnail[],
 }
 
 export const initialState: video & httpRequestState = {
@@ -48,6 +49,7 @@ export const initialState: video & httpRequestState = {
   title: '',
   presenters: [],
   workflows: [],
+  thumbnails: [],
 
   status: 'idle',
   error: undefined,
@@ -125,6 +127,17 @@ const videoSlice = createSlice({
     },
     setWaveformImages: (state, action: PayloadAction<video["waveformImages"]>) => {
       state.waveformImages = action.payload
+    },
+    setThumbnails: (state, action: PayloadAction<video["thumbnails"]>) => {
+      state.thumbnails = action.payload
+    },
+    setThumbnail: (state, action: PayloadAction<Thumbnail>) => {
+      const index = state.thumbnails.findIndex(t => t.videoId === action.payload.videoId)
+      if (index >= 0) {
+        state.thumbnails[index] = action.payload
+      } else {
+        state.thumbnails.push(action.payload)
+      }
     },
     cut: (state) => {
       // If we're exactly between two segments, we can't split the current segment
@@ -304,8 +317,8 @@ const calculateTotalAspectRatio = (aspectRatios: video["aspectRatios"]) => {
 }
 
 export const { setTrackEnabled, setIsPlaying, setIsPlayPreview, setCurrentlyAt, setCurrentlyAtInSeconds,
-  addSegment, setAspectRatio, setHasChanges, setWaveformImages, cut, markAsDeletedOrAlive, setSelectedWorkflowIndex,
-  mergeLeft, mergeRight, setPreviewTriggered, setClickTriggered } = videoSlice.actions
+  addSegment, setAspectRatio, setHasChanges, setWaveformImages, setThumbnails, setThumbnail, cut, markAsDeletedOrAlive,
+  setSelectedWorkflowIndex, mergeLeft, mergeRight, setPreviewTriggered, setClickTriggered } = videoSlice.actions
 
 // Export selectors
 // Selectors mainly pertaining to the video state
@@ -345,6 +358,7 @@ export const selectTitle = (state: { videoState: { title: video["title"] } }) =>
 export const selectPresenters = (state: { videoState: { presenters: video["presenters"] } }) => state.videoState.presenters
 export const selectTracks = (state: { videoState: { tracks: video["tracks"] } }) => state.videoState.tracks
 export const selectWorkflows = (state: { videoState: { workflows: video["workflows"] } }) => state.videoState.workflows
+export const selectThumbnails = (state: { videoState: { thumbnails: video["thumbnails"] } }) => state.videoState.thumbnails
 export const selectAspectRatio = (state: { videoState: { aspectRatios: video["aspectRatios"] } }) =>
   calculateTotalAspectRatio(state.videoState.aspectRatios)
 

--- a/src/redux/videoSlice.ts
+++ b/src/redux/videoSlice.ts
@@ -139,6 +139,12 @@ const videoSlice = createSlice({
         state.thumbnails.push(action.payload)
       }
     },
+    removeThumbnail: (state, action: PayloadAction<string>) => {
+      const index = state.thumbnails.findIndex(t => t.videoId === action.payload)
+      if (index > -1) {
+        state.thumbnails.splice(index, 1);
+      }
+    },
     cut: (state) => {
       // If we're exactly between two segments, we can't split the current segment
       if (state.segments[state.activeSegmentIndex].start === state.currentlyAt ||
@@ -317,8 +323,9 @@ const calculateTotalAspectRatio = (aspectRatios: video["aspectRatios"]) => {
 }
 
 export const { setTrackEnabled, setIsPlaying, setIsPlayPreview, setCurrentlyAt, setCurrentlyAtInSeconds,
-  addSegment, setAspectRatio, setHasChanges, setWaveformImages, setThumbnails, setThumbnail, cut, markAsDeletedOrAlive,
-  setSelectedWorkflowIndex, mergeLeft, mergeRight, setPreviewTriggered, setClickTriggered } = videoSlice.actions
+  addSegment, setAspectRatio, setHasChanges, setWaveformImages, setThumbnails, setThumbnail, removeThumbnail,
+  cut, markAsDeletedOrAlive, setSelectedWorkflowIndex, mergeLeft, mergeRight, setPreviewTriggered,
+  setClickTriggered } = videoSlice.actions
 
 // Export selectors
 // Selectors mainly pertaining to the video state

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export interface Track {
   flavor: Flavor,
   audio_stream: any,
   video_stream: any,
+  thumbnailUri: string | undefined,
 }
 
 export interface Flavor {
@@ -28,12 +29,6 @@ export interface Workflow {
 export interface TimelineState {
   segments: Segment[]
   scrubberPos: number
-}
-
-export interface Thumbnail {
-  videoId: string,
-  flavor: Flavor,
-  uri: string,
 }
 
 export interface PostEditArgument {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,9 +8,14 @@ export interface Segment {
 export interface Track {
   id: string,
   uri: string,
-  flavor: any,
+  flavor: Flavor,
   audio_stream: any,
   video_stream: any,
+}
+
+export interface Flavor {
+  type: string,
+  subtype: string,
 }
 
 export interface Workflow {
@@ -23,6 +28,12 @@ export interface Workflow {
 export interface TimelineState {
   segments: Segment[]
   scrubberPos: number
+}
+
+export interface Thumbnail {
+  videoId: string,
+  flavor: Flavor,
+  uri: string,
 }
 
 export interface PostEditArgument {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export interface Track {
   audio_stream: any,
   video_stream: any,
   thumbnailUri: string | undefined,
+  thumbnailPriority: number,
 }
 
 export interface Flavor {


### PR DESCRIPTION
Adds a new view which allows users to create thumbnails for their events.

Allows users to:
- Generate a thumbnail from a video at a selected point in time.
- Upload a thumbnail.
- Set the same thumbnail for all videos.
- Discard any changes they made.

Has a "simple" and a "professional" mode.
- Simple: For when you only care about one primary thumbnail.
- Professional: When you want to be able to change all the thumbnails in the subflavor.

Requires Opencast backend PR to function: https://github.com/opencast/opencast/pull/4086