### PR TITLE
make TrackSelection respect theme selection for menu headings

### DIFF
--- a/src/main/TrackSelection.tsx
+++ b/src/main/TrackSelection.tsx
@@ -62,6 +62,8 @@ const Description: React.FC<{}> = () => {
 
 const TrackItem: React.FC<{track: Track, enabledCount: number}> = ({track, enabledCount}) => {
 
+  const theme = useSelector(selectTheme);
+
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const header = track.flavor.type + ' '

--- a/src/main/TrackSelection.tsx
+++ b/src/main/TrackSelection.tsx
@@ -90,7 +90,7 @@ const TrackItem: React.FC<{track: Track, enabledCount: number}> = ({track, enabl
     width: '100%',
     fontWeight: 'bold',
     padding: '5px 25px',
-    borderBottom: '1px solid white',
+    borderBottom: `${theme.menuBorder}`,
     textTransform: 'capitalize',
     fontSize: 'larger',
   });


### PR DESCRIPTION
The CSS property `border-bottom` for the menu headings on the Track Selection was hard coded to `1px solid white`, which works great for the dark theme, but not so much for the light theme.

Before:
![Screen Shot 2022-08-30 at 17 03 41](https://user-images.githubusercontent.com/856916/187472621-902f2bde-7ffe-4e6c-9786-ce1909967b2a.png)

After:
![Screen Shot 2022-08-30 at 17 03 57](https://user-images.githubusercontent.com/856916/187472653-7f50d3eb-935c-4cb5-8d63-3d5882de4f8f.png)

