### PR TITLE
Changed "saved successfully" to suggest that the editor can be closed now

### DIFF
--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -54,7 +54,7 @@
       "confirmButton-success-tooltip": "Saved successfully",
       "confirmButton-failed-tooltip": "Save failed",
       "info-text": "The video will not be processed but all cutting information will be stored in Opencast. You can continue your edit later.",
-      "success-text": "Changes saved successfully!",
+      "success-text": "Changes saved successfully! You can now close the editor or continue working.",
       "success-tooltip-aria": "Saved successfully",
       "saveArea-tooltip": "Save Area"
     },


### PR DESCRIPTION
It has been brought to my attention that, unlike me who often continues using the editor after clicking on "save", most normal users would want to exit the editor in some fashion after they have saved their work. This PR changes the post-save text to indicate that is now safe to close the editor. This also brings the text more in line with the post-process and post-discard text which both have this hint already.