### PR TITLE
Enable running the 'Update translations' workflow manually

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -2,7 +2,8 @@ name: Update translations
 
 on:
   schedule:
-  - cron: "0 5 * * 1"
+    - cron: "0 5 * * 1"
+  workflow_dispatch:
 
 jobs:
   update-translations:


### PR DESCRIPTION
This allows updating the translations manually just before cutting a release.