### PR TITLE
change cursor style to text for react-select multi CreatableSelect

### DIFF
--- a/src/cssStyles.tsx
+++ b/src/cssStyles.tsx
@@ -178,6 +178,7 @@ export function selectFieldStyle(theme: Theme) {
       ...provided,
       color: theme.text,
       background: theme.multiValue,
+      cursor: 'default',
     }),
     multiValueLabel: (provided: any) =>({
       ...provided,
@@ -192,6 +193,10 @@ export function selectFieldStyle(theme: Theme) {
     placeholder: (provided: any) => ({
       ...provided,
       color: theme.text
-    })
+    }),
+    valueContainer: (provided: any) => ({
+      ...provided,
+      cursor: "text",
+    }),
   }
 }


### PR DESCRIPTION
The presenter and contributor fields in the metadata tab use a combined select input control with multi-select enabled. The actual <input> is only a few pixels wide, so when hovering over the control, it's not showing a text cursor indicating the possibility to input new text.

This commit sets the cursor on the `valueContainer` component to `text` and resets it to `default` on the `multiValue` component.

For the list of available components for React-Select see: https://react-select.com/components

Fixes: #785