### PR TITLE
Default subtitle flavor configuration

### DIFF
--- a/public/editor-settings.toml
+++ b/public/editor-settings.toml
@@ -113,8 +113,9 @@ password = "opencast"
 #
 # Example:
 [subtitles.languages]
-# "captions/source+de" = "Deutsch"
-# "captions/source+en" = "English"
+"captions/vtt+en" = "English"
+"captions/vtt+de" = "German"
+"captions/vtt+es" = "Spanish"
 
 # Specify the default video in the subtitle video player by flavor
 # If not specified, the editor will decide on a default by itself


### PR DESCRIPTION
This patch provides a default subtitle flavor configuration which should work with many installations out of the box.

More than that, it should never cause any trouble because the subtitle editor by itself is still hidden by default.