### PR TITLE
Improve GHA

### DIFF
--- a/.github/workflows/cleanup-deployments.yml
+++ b/.github/workflows/cleanup-deployments.yml
@@ -23,11 +23,11 @@ jobs:
         path: editor-test
     
     - name: remove old builds
-      run: rm -rf editor-test/${{ github.event.number }}
+      run: rm -rf "$GITHUB_WORKSPACE/editor-test/${{ github.event.number }}"
 
     - name: regenerate index.html
       run: |
-        cd ~/editor-test
+        cd "$GITHUB_WORKSPACE/editor-test"
         echo '<html><body><ul>' > index.html
         find . -maxdepth 2 -name '*_*' -type d \
           | sort -r \
@@ -37,5 +37,6 @@ jobs:
     - name: Commit changes
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
+        repository: $GITHUB_WORKSPACE/editor-test
         branch: gh-pages
         commit_message: Delete old deployments from PR ${{ github.event.number }}

--- a/.github/workflows/cleanup-deployments.yml
+++ b/.github/workflows/cleanup-deployments.yml
@@ -26,8 +26,8 @@ jobs:
       run: rm -rf "$GITHUB_WORKSPACE/editor-test/${{ github.event.number }}"
 
     - name: regenerate index.html
+      working-directory: $GITHUB_WORKSPACE/editor-test
       run: |
-        cd "$GITHUB_WORKSPACE/editor-test"
         echo '<html><body><ul>' > index.html
         find . -maxdepth 2 -name '*_*' -type d \
           | sort -r \

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: use node.js 16.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
 

--- a/.github/workflows/deploy-crowdin-keys.yml
+++ b/.github/workflows/deploy-crowdin-keys.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository_owner == 'opencast'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: prepare crowdin client
       run: |

--- a/.github/workflows/playwright-test.yml
+++ b/.github/workflows/playwright-test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Check out source code

--- a/.github/workflows/playwright-test.yml
+++ b/.github/workflows/playwright-test.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - name: Check out source code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install Node Dependency
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: 16
 

--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -8,17 +8,17 @@ on:
 
 jobs:
   main:
+    if: steps.is_team_member.outputs.permitted == true
+    needs: member
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.head.repo.full_name == 'opencast/opencast-editor'
-      || github.event.pull_request.head.repo.full_name == 'Arnei/opencast-editor'
-      || github.event.pull_request.head.repo.full_name == 'naweidner/opencast-editor'
-      || github.event.pull_request.head.repo.full_name == 'lkiesow/opencast-editor' }}
+    
     steps:
     - name: generate build path
       run: echo "::set-output name=build::${{github.event.number}}/$(date +%Y-%m-%d_%H-%M-%S)/" | sed 's_build::/*_build::_'
       id: build-path
 
-    - uses: actions/checkout@v3
+    - name: Checkout Sources
+      uses: actions/checkout@v3
       with:
         ref: ${{github.event.pull_request.head.ref}}
         repository: ${{github.event.pull_request.head.repo.full_name}}
@@ -98,3 +98,40 @@ jobs:
           ](https://test.editor.opencast.org/${{ steps.build-path.outputs.build }}).
 
           It might take a few minutes for it to become available.
+
+
+  member:
+    name: Check organization membership
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check if team member
+        id: is_team_member
+        uses: TheModdingInquisition/actions-team-membership@v1.0
+        with:
+          team: developers # required. The team to check for
+          token: ${{ secrets.GITHUB_ORG_TOKEN }} # required. Personal Access Token with the `read:org` permission
+
+
+  translations:
+    name: Translations only via Crowdin
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Sources
+      uses: actions/checkout@v3
+
+    - name: Get changed locale files
+      uses: dorny/paths-filter@v2
+      id: filter_locales
+      with:
+        filters: | # !(pattern) matches anything but pattern
+          locales:
+            - 'src/i18n/locales/!(en-US)*.json'
+
+    - name: Check for changes in translations
+      if: steps.filter_locales.outputs.locales == true
+      uses: actions/github-script@v6
+      with:
+        script: |
+            core.setFailed('You should not alter translations outside of Crowdin.')

--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -18,13 +18,13 @@ jobs:
       run: echo "::set-output name=build::${{github.event.number}}/$(date +%Y-%m-%d_%H-%M-%S)/" | sed 's_build::/*_build::_'
       id: build-path
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{github.event.pull_request.head.ref}}
         repository: ${{github.event.pull_request.head.repo.full_name}}
 
     - name: use node.js 16.x
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: 16
 
@@ -48,7 +48,7 @@ jobs:
         chmod 600 ~/.ssh/id_ed25519
         ssh-keyscan github.com >> ~/.ssh/known_hosts
 
-    - name: wait for previoous workflows to finish
+    - name: wait for previous workflows to finish
       uses: softprops/turnstyle@v1
       with:
         same-branch-only: false

--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -23,23 +23,25 @@ jobs:
         ref: ${{github.event.pull_request.head.ref}}
         repository: ${{github.event.pull_request.head.repo.full_name}}
 
-    - name: use node.js 16.x
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v3
       with:
         node-version: 16
 
-    - run: npm ci
+    - name: Clean install
+      run: npm ci
 
-    - run: npm run build
+    - name: Build App
+      run: npm run build
       env:
         PUBLIC_URL: /${{ steps.build-path.outputs.build }}
 
-    - name: prepare git
+    - name: Prepare Git
       run: |
         git config --global user.name "Editor Deployment Bot"
         git config --global user.email "opencast-support@elan-ev.de"
 
-    - name: prepare github ssh key
+    - name: Prepare GitHub SSH key
       env:
         DEPLOY_KEY: ${{ secrets.DEPLOY_KEY_TEST }}
       run: |
@@ -48,27 +50,27 @@ jobs:
         chmod 600 ~/.ssh/id_ed25519
         ssh-keyscan github.com >> ~/.ssh/known_hosts
 
-    - name: wait for previous workflows to finish
+    - name: Wait for previous workflows to finish
       uses: softprops/turnstyle@v1
       with:
         same-branch-only: false
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: clone repository
+    - name: Clone repository
       run: |
         git clone "git@github.com:opencast/opencast-editor-test.git" ~/editor-test
         cd ~/editor-test
         git checkout gh-pages
 
-    - name: store build
+    - name: Store build
       env:
         DEPLOY_PATH: editor-test/${{ steps.build-path.outputs.build }}
       run: |
         mkdir -p "${HOME}/${DEPLOY_PATH}"
         cp -rv build/* "${HOME}/${DEPLOY_PATH}"
 
-    - name: generate index.html
+    - name: Generate index.html
       run: |
         cd ~/editor-test
         echo '<html><body><ul>' > index.html
@@ -77,18 +79,18 @@ jobs:
           | sed 's/^\(.*\)$/<li><a href=\1>\1<\/a><\/li>/' >> index.html
         echo '</ul></body></html>' >> index.html
 
-    - name: commit new version
+    - name: Commit new version
       run: |
         cd ~/editor-test
         git add .
         git commit -m "Build ${{ steps.build-path.outputs.build }}"
 
-    - name: push updates
+    - name: Push updates
       run: |
         cd ~/editor-test
         git push origin gh-pages
 
-    - name: add comment with deployment location
+    - name: Add comment with deployment location
       uses: thollander/actions-comment-pull-request@main
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   main:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.head.repo.full_name == 'opencast/opencast-editor'
       || github.event.pull_request.head.repo.full_name == 'Arnei/opencast-editor'
       || github.event.pull_request.head.repo.full_name == 'naweidner/opencast-editor'

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.repository_owner == 'opencast'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: prepare git
         run: |

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -17,28 +17,31 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout sources
+      uses: actions/checkout@v3
 
-    - name: use node.js 16.x
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v3
       with:
         node-version: 16
 
-    - run: npm ci
+    - name: Clean install
+      run: npm ci
 
-    - run: npm run build
+    - name: Build App
+      run: npm run build
 
     # tests are currently failing
     #- run: npm test
     #  env:
     #    CI: true
 
-    - name: prepare git
+    - name: Prepare git
       run: |
         git config --global user.name "Editor Deployment Bot"
         git config --global user.email "opencast-support@elan-ev.de"
 
-    - name: prepare github ssh key
+    - name: Prepare GitHub SSH key
       env:
         DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
       run: |
@@ -47,13 +50,13 @@ jobs:
         chmod 600 ~/.ssh/id_ed25519
         ssh-keyscan github.com >> ~/.ssh/known_hosts
 
-    - name: clone repository
+    - name: Clone repository
       run: |
         git clone "git@github.com:opencast/opencast-editor.git" ~/editor-clone
         cd ~/editor-clone
         git checkout gh-pages
 
-    - name: commit new version
+    - name: Commit new version
       run: |
         # store build
         cp -r build ~/editor-build
@@ -68,7 +71,7 @@ jobs:
         git add ./*
         git diff --staged --quiet || git commit -m "Build $(date)"
 
-    - name: push updates
+    - name: Push updates
       run: |
         cd ~/editor-clone
         git push origin gh-pages

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -17,10 +17,10 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: use node.js 16.x
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: 16
 


### PR DESCRIPTION
This improves and fixes several GHA workflows.

### customized editor-settings.toml for deployments

Add a `editor-settings.toml` just for deployments to editor.opencast.org and test.editor.opencast.org. This enables setting certain config values for testing deployments we do not want to ship (yet).


### Update GitHub-actions

- Update to actions/checkout@v3 and actions/setup-node@v3
- Run GitHub Actions on the latest ubuntu


### fix GHA workflow 'cleanup deployment'

The steps were running in different working directories. Now they all run relative to GITHUB_WORKSPACE


### add check for opencast developers team membership for deployments

Currently, the Test & Deploy workflow only runs for selected pull requests. Adding a bunch of people to the list and keeping it up-to-date could turn out to be cumbersome. So this adds an additional workflow job and uses `TheModdingInquisition/actions-team-membership@v1.0` to check the membership of the person opening the PR. If the person is part of the `opencast/developers` team, the workflow will run.

**The `actions-team-membership` action needs a new Personal Access Token `GITHUB_ORG_TOKEN` with the `read:org` permission.**


### Check for updates to translations outside of Crowdin

This is done for two reasons:
1. This prevents possible merge conflicts when translations on Crowdin get updated.
2. As we are only uploading translation sources and not the translations themself to Crowdin, the translations on Crowdin and here in the repository would diverge and local changes would be overwritten with the next Crowdin update.