### PR TITLE
Remove superfluos "=" on landing page

### DIFF
--- a/src/main/Landing.tsx
+++ b/src/main/Landing.tsx
@@ -42,7 +42,7 @@ import { useTranslation } from 'react-i18next';
         </li>
         <li>
           {t("landing.start-editing-1")}
-          <code> ?=id=[media-package-id]</code>
+          <code> ?id=[media-package-id]</code>
           {t("landing.start-editing-2")}
         </li>
         <li>


### PR DESCRIPTION
If you blindly copy and paste the query parameter into your browsers address window (and change the mp id), you just land on the landing page again, leaving you a bit stumped before figuring out the typo.