### PR TITLE
Split demo and production configuration

### DIFF
--- a/editor-settings.toml
+++ b/editor-settings.toml
@@ -1,0 +1,151 @@
+####
+# Opencast Stand-alone Video Editor
+##
+
+# This file contains the editord default configuration and our recommendation for production use.
+# All values in here aer set to their defaults.
+
+# ⚠️  When deployed, this file is publicly accessibly!
+
+
+####
+# Metadata
+##
+
+[metadata]
+# If the metadata editor appears in the main menu
+# Type: boolean
+# Default: true
+#show = true
+
+## Metadata display configuration
+## Override various settings for how metadata catalogs and fields will be
+## displayed in the editor. Configuration happens for each catalog separately.
+##
+## Configuration options for fields:
+##
+##   show (boolean): Show or hide fields
+##   readonly (boolean): Mark fields as readonly
+##
+## Default behavior:
+##
+## - The default settings are based on Opencast's admin interface configuration
+## - If catalogs are not specified, all of its fields will be displayed
+## - If a catalog is specified but empty, it will not be displayed
+##
+## Example:
+##
+# # This is the default catalog
+# [metadata.configureFields."EVENTS.EVENTS.DETAILS.CATALOG.EPISODE"]
+# title = {show = true, readonly = false}
+# subject = {show = false}
+# description = {readonly = true}
+#
+# # This catalog is specified but empty, and as such will not be displayed
+# [metadata.configureFields."NameOfAnExtendedMetadataCatalog"]
+
+
+####
+# Track Selection
+##
+
+[trackSelection]
+
+# If the track selection appears in the main menu
+# Type: boolean
+# Default: true
+#show = true
+
+####
+# Subtitles
+##
+
+[subtitles]
+
+# If the subtitle editor appears in the main menu
+# Before you enable the subtitle editor, you should define some languages
+# under "subtitles.languages"
+# Type: boolean
+# Default: false
+#show = false
+
+# The main flavor of the subtitle tracks in Opencast
+# No other tracks should have the same main flavor as subtitle tracks
+# Type: string
+# Default: "captions"
+#mainFlavor = "captions"
+
+[subtitles.languages]
+## A list of languages for which subtitles can be created
+"captions/source+de" = "Deutsch"
+"captions/source+en" = "English"
+"captions/source+es" = "Spanish"
+
+[subtitles.defaultVideoFlavor]
+# Specify the default video in the subtitle video player by flavor
+# If not specified, the editor will decide on a default by itself
+# "type" = "presentation"
+# "subtype" = "preview"
+
+####
+# Thumbnail Selection
+##
+
+[thumbnail]
+
+# If the thumbnail editor appears in the main menu
+# Type: boolean
+# Default: false
+#show = false
+
+# Whether to use "simple" or "professional" mode.
+# Professional mode allows users to edit all thumbnails that fit the subflavor
+# specified in the Opencast configuration file
+# `etc/org.opencastproject.editor.EditorServiceImpl.cfg`. It is useful
+# when working with multiple thumbnails.
+# Simple mode only allows users to edit the "primary" thumbnail, as specified
+# in the Opencast configuration file
+# `etc/org.opencastproject.editor.EditorServiceImpl.cfg`. It is useful
+# when there is only a single thumbnail to worry about and you want hide
+# potential fallbacks from the user. If a primary thumbnail cannot be
+# determined, this falls back to professional mode.
+# Type: boolean
+# Default: false
+#simpleMode = false
+
+
+
+############################################################
+# Settings for demo deployment
+############################################################
+
+# All settings from here on are ment for demo deployments and rarely useful for production.
+# In general, these should be completely left out from deployments in Opencast.
+
+
+# Id of the event that the editor should open by default.
+# This is very useful as demo, but has no purpose otherwise.
+# Type: string | undefined
+# Default: undefined
+#id =
+
+
+[opencast]
+
+# URL of the opencast server to connect to.
+# The default will work just fine if integrated in Opencast.
+# Type: URL
+# Default: Current server
+#url = 'https://develop.opencast.org'
+
+# Username for HTTP basic authentication against Opencast.
+# Not defining this will work just fine if integrated in Opencast.
+# Type: string | undefined
+# Default: undefined
+#name =
+
+# Password for HTTP basic authentication against Opencast.
+# Not defining this will work just fine if integrated in Opencast.
+# Type: string | undefined
+# Default: undefined
+#password =

--- a/public/editor-settings.toml
+++ b/public/editor-settings.toml
@@ -2,146 +2,36 @@
 # Opencast Stand-alone Video Editor
 ##
 
-# !!! When deployed, this file is publicly accessibly
+# This file contains configuration meant for development and demonstration.
+# New features should be enabled in here to make testing easier.
 
-####
-# General Settings
-##
+# ⚠️  Please do not use this for production deployments.
 
-# Id of the event that the editor should open by default.
-# This is very useful as demo, but has no purpose otherwise.
-# Type: string | undefined
-# Default: undefined
+
+# Pick a default event identifier which should be on develop.opencast.org
 id = 'ID-dual-stream-demo'
 
-
-####
-# Connection to Opencast
-##
-
 [opencast]
-
-# URL of the opencast server to connect to.
-# The default will work just fine if integrated in Opencast.
-# Type: URL
-# Default: Current server
+# Connect to develop.opencast.org and use the default demo user
 url = 'https://develop.opencast.org'
-
-
-
-# Username, used for HTTP basic authentication against Opencast.
-# Not defining this will work just fine if integrated in Opencast.
-# Type: string | undefined
-# Default: undefined
 name = "admin"
-
-# Username, used for HTTP basic authentication against Opencast.
-# Not defining this will work just fine if integrated in Opencast.
-# Type: string | undefined
-# Default: undefined
 password = "opencast"
 
 
-####
-# Metadata
-##
-
 [metadata]
-# If the metadata editor appears in the main menu
-# Type: boolean
-# Default: true
-#show = true
-
-## Metadata display configuration
-## Override various settings for how metadata catalogs and fields will be
-## displayed in the editor. Configuration happens for each catalog separately.
-##
-## Configuration options for fields:
-##
-##   show (boolean): Show or hide fields
-##   readonly (boolean): Mark fields as readonly
-##
-## Default behavior:
-##
-## - The default settings are based on Opencast's admin interface configuration
-## - If catalogs are not specified, all of its fields will be displayed
-## - If a catalog is specified but empty, it will not be displayed
-##
-## Example:
-##
-# # This is the default catalog
-# [metadata.configureFields."EVENTS.EVENTS.DETAILS.CATALOG.EPISODE"]
-# title = {show = true, readonly = false}
-# subject = {show = false}
-# description = {readonly = true}
-#
-# # This catalog is specified but empty, and as such will not be displayed
-# [metadata.configureFields."NameOfAnExtendedMetadataCatalog"]
-
-
-####
-# Track Selection
-##
-
-[trackSelection]
-
-# If the track selection appears in the main menu
-# Type: boolean
-# Default: true
-#show = true
-
-####
-# Subtitles
-##
-
-[subtitles]
-
-# If the subtitle editor appears in the main menu
-# Before you enable the subtitle editor, you should define some languages
-# under "subtitles.languages"
-# Type: boolean
-# Default: false
-#show = false
-
-# The main flavor of the subtitle tracks in Opencast
-# No other tracks should have the same main flavor as subtitle tracks
-# Type: string
-# Default: "captions"
-#mainFlavor = "captions"
-
-## A list of languages for which subtitles can be created
-#
-# Example:
-[subtitles.languages]
-# "captions/source+de" = "Deutsch"
-# "captions/source+en" = "English"
-
-# Specify the default video in the subtitle video player by flavor
-# If not specified, the editor will decide on a default by itself
-#[subtitles.defaultVideoFlavor]
-# "type" = "presentation"
-# "subtype" = "preview"
-
-####
-# Thumbnail Selection
-##
-
-[thumbnail]
-
-# If the thumbnail editor appears in the main menu
-# Type: boolean
-# Default: false
 show = true
 
-# Whether to use "simple" or "professional" mode.
-# Professional mode allows users to edit all thumbnails that fit the subflavor
-# specified in the Opencast configuration file
-# `etc/org.opencastproject.editor.EditorServiceImpl.cfg`. It is useful
-# when working with multiple thumbnails.
-# Simple mode only allows users to edit the "primary" thumbnail, as specified
-# in the Opencast configuration file
-# `etc/org.opencastproject.editor.EditorServiceImpl.cfg`. It is useful
-# when there is only a single thumbnail to worry about and you want hide
-# potential fallbacks from the user. If a primary thumbnail cannot be
-# determined, this falls back to professional mode.
-simpleMode = false
+[trackSelection]
+show = true
+
+[subtitles]
+show = true
+mainFlavor = "captions"
+
+[subtitles.languages]
+"captions/source+de" = "Deutsch"
+"captions/source+en" = "English"
+"captions/source+es" = "Spanish"
+
+[thumbnail]
+show = true


### PR DESCRIPTION
This patch splits the configuration file to provide two separate versions:

- `editor-settings.toml` which is our recommended configuration for production, has all the default settings and documenta all configuration options.

- `public/editor-settings.toml` which is used for development (`npm run start` will use this) and for demo deployments. It should enable new features by default to make testing easier.

This closes #837