### PR TITLE
Keep Playwright Test Results

### DIFF
--- a/.github/workflows/playwright-test.yml
+++ b/.github/workflows/playwright-test.yml
@@ -40,3 +40,9 @@ jobs:
 
     - name: Run playwright-test
       run: npx playwright test --config=playwright.config.ts
+
+    - name: Upload tests results
+      uses: actions/upload-artifact@v3
+      with:
+        name: test-results
+        path: test-results/

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,12 +5,13 @@ const config: PlaywrightTestConfig = {
   reporter: [ [process.env.CI ? 'github' : 'list',],
             ['html', { outputFolder: 'playwright-report' }]],
   testIgnore: '**/redux/**',
-  retries: 3,
+  retries: 1,
   timeout: 60 * 1000,
 
   use: {
     baseURL: 'http://localhost:3000/',
     headless: true,
+    screenshot: 'only-on-failure',
   },
 
   webServer: {


### PR DESCRIPTION
This patch makes Playwright take screenshots of failing tests and will upload them alongside the test result report to the GitHub Actions workflow artifacts. This makes it easier to get information about what is failing if a test is failing.

This also limits the number of retries: If we have to retry three times to pass a test something is definitely wrong. Either with the code or with the test.