### PR TITLE
Add aria-label to theme selector

### DIFF
--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -276,6 +276,7 @@
 
     "theme": {
       "appearance": "Appearance",
+      "selectThemesLabel": "Appearances",
       "darkmode": "Dark mode",
       "lightmode": "Light mode",
       "system": "System design",

--- a/src/main/ThemeSwitcher.tsx
+++ b/src/main/ThemeSwitcher.tsx
@@ -76,6 +76,7 @@ const ThemeSwitcher: React.FC<{}> = () => {
         defaultValue={themes.filter(({value}) => value === themeState)}
         options={themes}
         onChange={themes => switchTheme(themes!.value)}
+        aria-label={t('theme.selectThemesLabel')}
       />
     </div>
   )


### PR DESCRIPTION
The appearance selector, which is used to select themes for accessibility is missing an aria-label.