### PR TITLE
Fix Dependabot test deployment

### DIFF
--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -8,7 +8,8 @@ on:
 
 jobs:
   main:
-    if: needs.member.outputs.is_team_member
+    if: ${{ needs.member.outputs.is_team_member == 'true'
+      || github.event.pull_request.head.repo.full_name == 'opencast/opencast-editor' }}
     needs: member
     runs-on: ubuntu-latest
 
@@ -113,6 +114,7 @@ jobs:
     steps:
       - name: Check if user is Opencast developer
         id: is_developer
+        if: ${{ github.event.pull_request.head.repo.full_name != 'opencast/opencast-editor' }}
         uses: TheModdingInquisition/actions-team-membership@v1.0
         with:
           team: developers
@@ -122,6 +124,7 @@ jobs:
 
       - name: Check if user is Opencast committer
         id: is_committer
+        if: ${{ github.event.pull_request.head.repo.full_name != 'opencast/opencast-editor' }}
         uses: TheModdingInquisition/actions-team-membership@v1.0
         with:
           team: committers


### PR DESCRIPTION
This patch fixes the test and deploy GitHub Actions workflow if the pull request author is Dependabot by skipping the team membership test if the pull request source is already the target repository.

This fixes #877