### PR TITLE
Run Tests on Dependabot only once

### DIFF
--- a/.github/workflows/playwright-test.yml
+++ b/.github/workflows/playwright-test.yml
@@ -2,6 +2,8 @@ name: Playwright UI-Test
 
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
This patch updates the Playwright tests to no longer run twice on pull requests created by Dependabot.