### PR TITLE
Make active workflow warning less technical

### DIFF
--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -199,7 +199,7 @@
       "generic-message": "A critical error has occurred!",
       "details": "Details: ",
       "workflowActive-errorTitle": "Temporarily unavailable",
-      "workflowActive-errorMessage": "An Opencast workflow is currently running, please wait until it is finished."
+      "workflowActive-errorMessage": "This event is being processed. Please wait until the process is finished."
     },
 
     "landing": {

--- a/src/redux/videoSlice.ts
+++ b/src/redux/videoSlice.ts
@@ -208,7 +208,7 @@ const videoSlice = createSlice({
         if (action.payload.workflow_active) {
           state.status = 'failed'
           state.errorReason = 'workflowActive'
-          state.error = "An Opencast workflow is currently running, please wait until it is finished."
+          state.error = "This event is being processed. Please wait until the process is finished."
         }
         state.tracks = action.payload.tracks.sort((a: { thumbnailPriority: number; },b: { thumbnailPriority: number; }) => a.thumbnailPriority - b.thumbnailPriority)
         const videos = state.tracks.filter((track: Track) => track.video_stream.available === true)


### PR DESCRIPTION
This patch updates the warning users get when an active workflow is running on the event that is being loaded in the editor.

- Technically, the error message was not correct since it's not the problem that a workflow is being processed in Opencast, but that this workflow is running on the event the user tries to edit.
- The wording was very technical. A non-technical user does not know what a workflow in the context of Opencast is and what is happening.

This patch changes the message to tell users that the event they want to edit is being processed. That should hopefully be easier to understand.