### PR TITLE
Remove unused code

### DIFF
--- a/src/redux/videoSlice.ts
+++ b/src/redux/videoSlice.ts
@@ -190,21 +190,6 @@ const videoSlice = createSlice({
       fetchVideoInformation.fulfilled, (state, action) => {
         state.status = 'success'
 
-        // // Old API
-        // // eslint-disable-next-line no-sequences
-        // state.videoURLs = action.payload.previews.reduce((a: string[], o: { uri: string }) => (a.push(o.uri), a), [])
-        // state.videoCount = action.payload.previews.length
-        // state.duration = action.payload.duration
-        // state.title = action.payload.title
-        // state.presenters = action.payload.presenters
-        // state.segments = parseSegments(action.payload.segments, action.payload.duration)
-        // state.workflows = action.payload.workflows.sort((n1: { displayOrder: number; },n2: { displayOrder: number; }) => {
-        //   if (n1.displayOrder > n2.displayOrder) { return 1; }
-        //   if (n1.displayOrder < n2.displayOrder) { return -1; }
-        //   return 0;
-        // });
-
-        // New API
         if (action.payload.workflow_active) {
           state.status = 'failed'
           state.errorReason = 'workflowActive'


### PR DESCRIPTION
This patch removes some old, commented out code. We don't need to keep that if it was meant to work with an old API that no longer exists.