### PR TITLE
Fix type mismatch for Select labels

### DIFF
--- a/src/main/SubtitleSelect.tsx
+++ b/src/main/SubtitleSelect.tsx
@@ -249,7 +249,7 @@ const SubtitleAddButton: React.FC<{languages: {subFlavor: string, title: string}
               */}
               <ThemeProvider theme={muiTheme}>
                 <Select
-                  label={t("subtitles.createSubtitleDropdown-label")}
+                  label={t("subtitles.createSubtitleDropdown-label") ?? undefined}
                   name="languages"
                   data={selectData()}
                 >

--- a/src/main/SubtitleVideoArea.tsx
+++ b/src/main/SubtitleVideoArea.tsx
@@ -207,7 +207,7 @@ const VideoSelectDropdown : React.FC<{
 
           <ThemeProvider theme={muiTheme}>
             <Select
-              label={t("subtitleVideoArea.selectVideoLabel")}
+              label={t("subtitleVideoArea.selectVideoLabel") ?? undefined}
               name={dropdownName}
               data={selectData()}
             />


### PR DESCRIPTION
Recent dependency updates have caused a type mismatch. This quells the mismatch by basically replacing null with undefined.