### PR TITLE
Fix preview button tooltip hotkey hardcoded

### DIFF
--- a/src/main/SubtitleSelect.tsx
+++ b/src/main/SubtitleSelect.tsx
@@ -249,7 +249,7 @@ const SubtitleAddButton: React.FC<{languages: {subFlavor: string, title: string}
               */}
               <ThemeProvider theme={muiTheme}>
                 <Select
-                  label={t("subtitles.createSubtitleDropdown-label")}
+                  label={t("subtitles.createSubtitleDropdown-label") ?? undefined}
                   name="languages"
                   data={selectData()}
                 >

--- a/src/main/SubtitleVideoArea.tsx
+++ b/src/main/SubtitleVideoArea.tsx
@@ -207,7 +207,7 @@ const VideoSelectDropdown : React.FC<{
 
           <ThemeProvider theme={muiTheme}>
             <Select
-              label={t("subtitleVideoArea.selectVideoLabel")}
+              label={t("subtitleVideoArea.selectVideoLabel") ?? undefined}
               name={dropdownName}
               data={selectData()}
             />

--- a/src/main/Video.tsx
+++ b/src/main/Video.tsx
@@ -553,10 +553,12 @@ const PreviewMode: React.FC<{
   })
 
   return (
-    <ThemedTooltip title={t("video.previewButton-tooltip", { status: (isPlayPreview ? "on" : "off"), hotkeyName: "Control+Alt+p" })}>
+    <ThemedTooltip
+      title={t("video.previewButton-tooltip", { status: (isPlayPreview ? "on" : "off"),
+      hotkeyName: (videoPlayerKeyMap[handlers.preview.name] as KeyMapOptions).sequence })}
+      >
       <div css={previewModeStyle}
         ref={ref}
-        title={t("video.previewButton-tooltip", { status: (isPlayPreview ? "on" : "off"), hotkeyName: (videoPlayerKeyMap[handlers.preview.name] as KeyMapOptions).sequence })}
         role="switch" aria-checked={isPlayPreview} tabIndex={0} aria-hidden={false}
         aria-label={t("video.previewButton-aria", { hotkeyName: (videoPlayerKeyMap[handlers.preview.name] as KeyMapOptions).sequence })}
         onClick={ (event: SyntheticEvent) => switchPlayPreview(event, ref) }


### PR DESCRIPTION
Hotkey for the preview button was hardcoded and would thus show incorrectly for i.e. MacOS users.

(Contains https://github.com/opencast/opencast-editor/pull/892)