### PR TITLE
Remove dead code in video header

### DIFF
--- a/src/cssStyles.tsx
+++ b/src/cssStyles.tsx
@@ -172,7 +172,7 @@ export const titleStyle = css(({
   overflow: 'hidden',
   whiteSpace: "nowrap",
   textOverflow: 'ellipsis',
-  maxWidth: '500px',
+  maxWidth: '100%',
 }))
 
 /**

--- a/src/main/SubtitleSelect.tsx
+++ b/src/main/SubtitleSelect.tsx
@@ -249,7 +249,7 @@ const SubtitleAddButton: React.FC<{languages: {subFlavor: string, title: string}
               */}
               <ThemeProvider theme={muiTheme}>
                 <Select
-                  label={t("subtitles.createSubtitleDropdown-label")}
+                  label={t("subtitles.createSubtitleDropdown-label") ?? undefined}
                   name="languages"
                   data={selectData()}
                 >

--- a/src/main/SubtitleVideoArea.tsx
+++ b/src/main/SubtitleVideoArea.tsx
@@ -207,7 +207,7 @@ const VideoSelectDropdown : React.FC<{
 
           <ThemeProvider theme={muiTheme}>
             <Select
-              label={t("subtitleVideoArea.selectVideoLabel")}
+              label={t("subtitleVideoArea.selectVideoLabel") ?? undefined}
               name={dropdownName}
               data={selectData()}
             />

--- a/src/main/Video.tsx
+++ b/src/main/Video.tsx
@@ -10,7 +10,7 @@ import { faPlay, faPause, faToggleOn, faToggleOff, faGears} from "@fortawesome/f
 import { useSelector, useDispatch } from 'react-redux';
 import {
   selectIsPlaying, selectCurrentlyAt, selectCurrentlyAtInSeconds, setIsPlaying,
-  fetchVideoInformation, selectVideoURL, selectVideoCount, selectDurationInSeconds, selectTitle, selectPresenters,
+  fetchVideoInformation, selectVideoURL, selectVideoCount, selectDurationInSeconds, selectTitle,
   setPreviewTriggered, selectPreviewTriggered, selectIsPlayPreview, setIsPlayPreview, setAspectRatio, selectAspectRatio, selectDuration, setClickTriggered, selectClickTriggered, setCurrentlyAt
 } from '../redux/videoSlice'
 
@@ -657,22 +657,12 @@ const TimeDisplay: React.FC<{
  */
 const VideoHeader: React.FC<{}> = () => {
 
-  const { t } = useTranslation();
-
   const title = useSelector(selectTitle)
   const metadataTitle = useSelector(selectTitleFromEpisodeDc)
-  const presenters = useSelector(selectPresenters)
 
-  let presenter_header;
-  if (presenters && presenters.length) {
-      presenter_header = <div css={titleStyle} title={t("video.presenter-tooltip")}>by {presenters.join(", ")}</div>
-  }
   return (
-    <div css={{fontSize: '16px'}}>
-      <div css={[titleStyle, titleStyleBold]} title={t("video.title-tooltip")}>
+    <div css={[titleStyle, titleStyleBold]}>
         {metadataTitle ? metadataTitle : title}
-      </div>
-      {presenter_header}
     </div>
   );
 }

--- a/src/redux/__tests__/videoSlice.test.ts
+++ b/src/redux/__tests__/videoSlice.test.ts
@@ -1,7 +1,7 @@
 import reducer, { initialState, setIsPlaying, selectIsPlaying, setCurrentlyAt,
   selectCurrentlyAt, selectActiveSegmentIndex, selectPreviewTriggered,
   selectDuration, video, cut, selectSegments, markAsDeletedOrAlive, mergeRight,
-  fetchVideoInformation, selectVideoURL, selectTitle, selectPresenters,
+  fetchVideoInformation, selectVideoURL, selectTitle,
   selectTracks, selectWorkflows } from '../videoSlice'
 import cloneDeep from 'lodash/cloneDeep';
 import { httpRequestState } from '../../types';
@@ -332,7 +332,6 @@ describe('Video reducer', () => {
     expect(selectVideoURL(rootState)).toMatchObject(videoURLs);
     expect(selectDuration(rootState)).toEqual(dur);
     expect(selectTitle(rootState)).toEqual(title);
-    expect(selectPresenters(rootState)).toEqual([]);
     expect(selectTracks(rootState)).toMatchObject(tracks);
     expect(selectWorkflows(rootState)).toMatchObject(workflows);
   })

--- a/src/redux/videoSlice.ts
+++ b/src/redux/videoSlice.ts
@@ -218,7 +218,6 @@ const videoSlice = createSlice({
         state.captions = action.payload.subtitles ? state.captions = action.payload.subtitles : []
         state.duration = action.payload.duration
         state.title = action.payload.title
-        state.presenters = []
         state.segments = parseSegments(action.payload.segments, action.payload.duration)
         state.workflows = action.payload.workflows.sort((n1: { displayOrder: number; },n2: { displayOrder: number; }) => {
           return n1.displayOrder - n2.displayOrder;
@@ -386,7 +385,6 @@ export const selectVideoCount = (state: { videoState: { videoCount: video["video
 export const selectDuration = (state: { videoState: { duration: video["duration"] } }) => state.videoState.duration
 export const selectDurationInSeconds = (state: { videoState: { duration: video["duration"] } }) => state.videoState.duration / 1000
 export const selectTitle = (state: { videoState: { title: video["title"] } }) => state.videoState.title
-export const selectPresenters = (state: { videoState: { presenters: video["presenters"] } }) => state.videoState.presenters
 export const selectTracks = (state: { videoState: { tracks: video["tracks"] } }) => state.videoState.tracks
 export const selectWorkflows = (state: { videoState: { workflows: video["workflows"] } }) => state.videoState.workflows
 export const selectAspectRatio = (state: { videoState: { aspectRatios: video["aspectRatios"] } }) =>


### PR DESCRIPTION
Removes code that would display presenters in the video title in the
cutting view. Displaying presenters has been removed from the backend
for quite some time now and no one seems to have minded, so I think
this can just go.

Also resolves https://github.com/opencast/opencast-editor/issues/887 while I'm at it.

(Contains https://github.com/opencast/opencast-editor/pull/892)