### PR TITLE
Fix timeline marker in subtitle-editor being obscured

### DIFF
--- a/src/main/SubtitleSelect.tsx
+++ b/src/main/SubtitleSelect.tsx
@@ -249,7 +249,7 @@ const SubtitleAddButton: React.FC<{languages: {subFlavor: string, title: string}
               */}
               <ThemeProvider theme={muiTheme}>
                 <Select
-                  label={t("subtitles.createSubtitleDropdown-label")}
+                  label={t("subtitles.createSubtitleDropdown-label") ?? undefined}
                   name="languages"
                   data={selectData()}
                 >

--- a/src/main/SubtitleTimeline.tsx
+++ b/src/main/SubtitleTimeline.tsx
@@ -98,6 +98,7 @@ import { selectTheme } from "../redux/themeSlice";
           ...(refTop.current) && {left: (refTop.current.getElement().clientWidth / 2)},
           top: '10px',
           background: `${theme.text}`,
+          zIndex: 100,
         }}
       />
       {/* Scrollable timeline container. Has width of parent*/}

--- a/src/main/SubtitleVideoArea.tsx
+++ b/src/main/SubtitleVideoArea.tsx
@@ -207,7 +207,7 @@ const VideoSelectDropdown : React.FC<{
 
           <ThemeProvider theme={muiTheme}>
             <Select
-              label={t("subtitleVideoArea.selectVideoLabel")}
+              label={t("subtitleVideoArea.selectVideoLabel") ?? undefined}
               name={dropdownName}
               data={selectData()}
             />


### PR DESCRIPTION
Forces the marker to the front via CSS.

Resolves https://github.com/opencast/opencast-editor/issues/858

(Contains https://github.com/opencast/opencast-editor/pull/892)