### PR TITLE
Add editor files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@
 # production
 /build
 
+# editor files
+*.swp
+.vscode/
+
 # misc
 .DS_Store
 .env.local


### PR DESCRIPTION
This patch adds a few editor specific files to the `.gitignore` to to prevent them from accidentally being committed.