### PR TITLE
Do not highlight timeline segments in thumbnail editor

### DIFF
--- a/src/main/Thumbnail.tsx
+++ b/src/main/Thumbnail.tsx
@@ -101,6 +101,7 @@ const Thumbnail : React.FC<{}> = () => {
       />
       <Timeline
         timelineHeight={125}
+        styleByActiveSegment={false}
         selectIsPlaying={selectIsPlaying}
         selectCurrentlyAt={selectCurrentlyAt}
         setIsPlaying={setIsPlaying}

--- a/src/main/Timeline.tsx
+++ b/src/main/Timeline.tsx
@@ -35,6 +35,7 @@ import { ThemedTooltip } from './Tooltip';
  */
 const Timeline: React.FC<{
   timelineHeight?: number,
+  styleByActiveSegment?: boolean,
   selectCurrentlyAt: (state: RootState) => number,
   selectIsPlaying:(state: RootState) => boolean,
   setClickTriggered: ActionCreatorWithPayload<any, string>,
@@ -42,6 +43,7 @@ const Timeline: React.FC<{
   setIsPlaying: ActionCreatorWithPayload<boolean, string>,
 }> = ({
   timelineHeight = 250,
+  styleByActiveSegment = true,
   selectCurrentlyAt,
   selectIsPlaying,
   setClickTriggered,
@@ -81,7 +83,7 @@ const Timeline: React.FC<{
     />
     <div css={{position: 'relative', height: timelineHeight - 20 + 'px'}} >
       <Waveforms timelineHeight={timelineHeight}/>
-      <SegmentsList timelineWidth={width} timelineHeight={timelineHeight} styleByActiveSegment={true} tabable={true}/>
+      <SegmentsList timelineWidth={width} timelineHeight={timelineHeight} styleByActiveSegment={styleByActiveSegment} tabable={true}/>
     </div>
   </div>
   );
@@ -283,8 +285,8 @@ export const Scrubber: React.FC<{
 export const SegmentsList: React.FC<{
   timelineWidth: number,
   timelineHeight: number,
-  styleByActiveSegment: boolean,
-  tabable: boolean,
+  styleByActiveSegment?: boolean,
+  tabable?: boolean,
 }> = ({
   timelineWidth,
   timelineHeight,


### PR DESCRIPTION
In the thumbnail editor, a timeline similar to the one in the cutting view is visible. One thing they share is highlighting individual segments on the timeline. This makes no sense in the thumbnail editor, as you cannot interact with the segments at all. This fixes that.

Resolves #834