### PR TITLE
Fix Failing Playwright Tests

### DIFF
--- a/.github/workflows/playwright-test.yml
+++ b/.github/workflows/playwright-test.yml
@@ -40,6 +40,14 @@ jobs:
     - name: Prepare mock files
       run: cp -r .github/mock/editor public/
 
+    - name: Build editor
+      run: |
+        npm run build
+        cp public/editor-settings.toml build/
+
+    - name: Use production build for testing
+      run: sed -i 's/npm run start/python -m http.server --bind 127.0.0.1 --directory build 3000/' playwright.config.ts
+
     - name: Run playwright-test
       run: npx playwright test --config=playwright.config.ts
 


### PR DESCRIPTION
This patch fixes the problem that the initial runs of Playwright fail on pull requests all the time. While they eventually succeed on the second run, the failing tests still leave lots of unnecessary warnings on GitHub Actions.

The problem seems to be that the React test server can sometimes be awfully slow when starting up, causing the initial runs to fail with an empty page.

To prevent this, this pull request actually build the Editor instead before running the tests on the pre-build project.

This fixes #846