### PR TITLE
Fix language wording ES to local name

### DIFF
--- a/editor-settings.toml
+++ b/editor-settings.toml
@@ -79,7 +79,7 @@
 ## A list of languages for which subtitles can be created
 "captions/source+de" = "Deutsch"
 "captions/source+en" = "English"
-"captions/source+es" = "Spanish"
+"captions/source+es" = "Español"
 
 [subtitles.icons]
 # A list of icons to be displayed for languages defined above.

--- a/public/editor-settings.toml
+++ b/public/editor-settings.toml
@@ -31,7 +31,7 @@ mainFlavor = "captions"
 [subtitles.languages]
 "captions/source+de" = "Deutsch"
 "captions/source+en" = "English"
-"captions/source+es" = "Spanish"
+"captions/source+es" = "Español"
 "captions/source" = "Generic"
 
 [subtitles.icons]


### PR DESCRIPTION
We should use local names as language, as it is for "Deutsch" and "English" already. So it must "Español" instead of "Spanish".