### PR TITLE
Additional Hotkey to play back video in the subtitle editor

### DIFF
--- a/src/globalKeys.ts
+++ b/src/globalKeys.ts
@@ -42,6 +42,7 @@ export const videoPlayerKeyMap: KeyMap = {
   play: {
     name: "keyboardControls.videoPlayButton",
     sequence: rewriteKeys("Space"),
+    sequences: [rewriteKeys("Control+Alt+Space"), "Space"],
     action: "keydown",
     group: groupVideoPlayer,
   },

--- a/src/main/KeyboardControls.tsx
+++ b/src/main/KeyboardControls.tsx
@@ -16,7 +16,7 @@ const Group: React.FC<{name: string, entries: KeyMapDisplayOptions[]}> = ({name,
   const groupStyle = css({
     display: 'flex',
     flexDirection: 'column' as const,
-    width: '420px',
+    width: '460px',
     maxWidth: '50vw',
   });
 


### PR DESCRIPTION
Currently, users can not play/pause the video in the subtitle input field. These changes solve this problem by introducing an alternate hotkey `Strg` + `Alt` + `Space` to play and pause videos.

Resolves #901