### PR TITLE
Add type checking to i18n

### DIFF
--- a/src/i18n/i18next.d.ts
+++ b/src/i18n/i18next.d.ts
@@ -1,0 +1,13 @@
+// import the original type declarations
+import 'i18next';
+
+// import all namespaces (for the default language, only)
+import translation from '../i18n/locales/en-US.json';
+
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    resources: {
+      translation: typeof translation;
+    };
+  }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,6 +12,7 @@ import { MuiPickersUtilsProvider } from '@material-ui/pickers';
 import DateFnsUtils from '@date-io/date-fns';
 import { GlobalHotKeys } from 'react-hotkeys';
 
+import './i18n/config';
 
 // Load config here
 // Load the rest of the application and try to fetch the settings file from the

--- a/src/main/CuttingActions.tsx
+++ b/src/main/CuttingActions.tsx
@@ -22,7 +22,6 @@ import { GlobalHotKeys, KeySequence, KeyMapOptions } from "react-hotkeys";
 import { cuttingKeyMap } from "../globalKeys";
 import { ActionCreatorWithoutPayload } from "@reduxjs/toolkit";
 
-import './../i18n/config';
 import { useTranslation } from 'react-i18next';
 import { selectTheme, Theme } from "../redux/themeSlice";
 import { ThemedTooltip } from "./Tooltip";

--- a/src/main/Discard.tsx
+++ b/src/main/Discard.tsx
@@ -14,7 +14,6 @@ import { setEnd } from '../redux/endSlice'
 
 import { PageButton } from './Finish'
 
-import './../i18n/config';
 import { useTranslation } from 'react-i18next';
 import { selectTheme } from "../redux/themeSlice";
 

--- a/src/main/Error.tsx
+++ b/src/main/Error.tsx
@@ -9,7 +9,6 @@ import { useSelector } from 'react-redux';
 import { selectErrorDetails, selectErrorIcon, selectErrorMessage, selectErrorTitle } from '../redux/errorSlice'
 import { flexGapReplacementStyle } from "../cssStyles";
 
-import './../i18n/config';
 import { useTranslation } from 'react-i18next';
 
 /**

--- a/src/main/FinishMenu.tsx
+++ b/src/main/FinishMenu.tsx
@@ -11,7 +11,6 @@ import {
 import { useDispatch, useSelector } from 'react-redux';
 import { setState, setPageNumber, finish } from '../redux/finishSlice'
 
-import './../i18n/config';
 import { useTranslation } from 'react-i18next';
 import { selectTheme } from "../redux/themeSlice";
 

--- a/src/main/KeyboardControls.tsx
+++ b/src/main/KeyboardControls.tsx
@@ -1,4 +1,5 @@
 import { css } from "@emotion/react";
+import { TFuncKey } from "i18next";
 import React from "react";
 
 import { KeyMapDisplayOptions } from 'react-hotkeys';
@@ -7,10 +8,10 @@ import { useSelector } from "react-redux";
 import { flexGapReplacementStyle } from "../cssStyles";
 import { getAllHotkeys } from "../globalKeys";
 import { selectTheme } from "../redux/themeSlice";
-import i18next from "./../i18n/config";
 
-const Group: React.FC<{name: string, entries: KeyMapDisplayOptions[]}> = ({name, entries}) => {
+const Group: React.FC<{name: TFuncKey, entries: KeyMapDisplayOptions[]}> = ({name, entries}) => {
 
+  const { t } = useTranslation();
   const theme = useSelector(selectTheme);
 
   const groupStyle = css({
@@ -26,7 +27,7 @@ const Group: React.FC<{name: string, entries: KeyMapDisplayOptions[]}> = ({name,
 
   return (
     <div css={groupStyle}>
-      <h3 css={headingStyle}>{i18next.t(name)}</h3>
+      <h3 css={headingStyle}>{t(name)}</h3>
       {entries.map((entry: KeyMapDisplayOptions, index: number) => (
         <Entry params={entry} key={index}></Entry>
       ))}
@@ -117,7 +118,7 @@ const KeyboardControls: React.FC<{}> = () => {
   const render = () => {
     if (keyMap && Object.keys(keyMap).length > 0) {
 
-      var obj: Record<string,Array<KeyMapDisplayOptions>> = {}
+      var obj: Record<string, Array<KeyMapDisplayOptions>> = {}
       obj[t("keyboardControls.defaultGroupName")] = []    // For keys without a group
 
       // Sort by group
@@ -136,7 +137,7 @@ const KeyboardControls: React.FC<{}> = () => {
       const groups: JSX.Element[] = [];
       for (const key in obj) {
         if (obj[key].length > 0) {
-          groups.push(<Group name={key} entries={obj[key]} key={key}/>);
+          groups.push(<Group name={key as TFuncKey} entries={obj[key]} key={key}/>);
         }
       }
 

--- a/src/main/Landing.tsx
+++ b/src/main/Landing.tsx
@@ -2,7 +2,6 @@ import React from "react";
 
 import { css } from '@emotion/react'
 
-import './../i18n/config';
 import { useTranslation } from 'react-i18next';
 
 /**

--- a/src/main/MainMenu.tsx
+++ b/src/main/MainMenu.tsx
@@ -15,7 +15,6 @@ import { settings } from '../config'
 import { basicButtonStyle, flexGapReplacementStyle } from '../cssStyles'
 import { setIsPlaying } from "../redux/videoSlice";
 
-import './../i18n/config';
 import { useTranslation } from 'react-i18next';
 import { resetPostRequestState as metadataResetPostRequestState } from "../redux/metadataSlice";
 import { resetPostRequestState } from "../redux/workflowPostSlice";

--- a/src/main/Metadata.tsx
+++ b/src/main/Metadata.tsx
@@ -20,8 +20,6 @@ import {
 } from 'mui-rff';
 import DateFnsUtils from "@date-io/date-fns";
 
-import './../i18n/config';
-import i18next from "./../i18n/config";
 import { useTranslation } from 'react-i18next';
 import { DateTime as LuxonDateTime} from "luxon";
 
@@ -31,6 +29,7 @@ import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { AppDispatch } from "../redux/store";
 import { selectTheme } from "../redux/themeSlice";
 import { ThemeProvider } from "@mui/material/styles";
+import { TFuncKey } from "i18next";
 
 /**
  * Creates a Metadata form
@@ -475,10 +474,10 @@ const Metadata: React.FC<{}> = () => {
         // Parse Label
         let descLabel = null
         if (i18n.exists(`metadata.${field.id}`)) {
-          descLabel = t(`metadata.${field.id}.${key.replaceAll(".", "-")}`)
+          descLabel = t(`metadata.${field.id}.${key.replaceAll(".", "-")}` as TFuncKey)
 
           if (field.id === "license") {
-            descLabel = t(`metadata.${field.id}.${JSON.parse(key).label.replaceAll(".", "-")}`)
+            descLabel = t(`metadata.${field.id}.${JSON.parse(key).label.replaceAll(".", "-")}` as TFuncKey)
           }
         }
 
@@ -552,8 +551,8 @@ const Metadata: React.FC<{}> = () => {
                   onBlur: (e: any) => {blurWithSubmit(e, input)},
                   showError: showErrorOnBlur
                 }}
-                leftArrowButtonText={i18next.t('metadata.calendar-prev')}
-                rightArrowButtonText={i18next.t('metadata.calendar-next')}
+                leftArrowButtonText={t('metadata.calendar-prev')}
+                rightArrowButtonText={t('metadata.calendar-next')}
               />
             </ThemeProvider>
           </LocalizationProvider>
@@ -629,7 +628,7 @@ const Metadata: React.FC<{}> = () => {
                   <div css={fieldStyle} data-testid={field.id}>
                     <label css={fieldLabelStyle} htmlFor={input.name}>{
                       i18n.exists(`metadata.labels.${field.id}`) ?
-                      t(`metadata.labels.${field.id}`) : field.id
+                      t(`metadata.labels.${field.id}` as TFuncKey) : field.id
                     }</label>
 
                     {generateComponentWithModifiedInput(field, input)}
@@ -649,7 +648,7 @@ const Metadata: React.FC<{}> = () => {
       <div key={catalogIndex}>
         <h2>
           {i18n.exists(`metadata.${catalog.title.replaceAll(".", "-")}`) ?
-            t(`metadata.${catalog.title.replaceAll(".", "-")}`) : catalog.title
+            t(`metadata.${catalog.title.replaceAll(".", "-")}` as TFuncKey) : catalog.title
           }
         </h2>
 

--- a/src/main/Save.tsx
+++ b/src/main/Save.tsx
@@ -16,7 +16,6 @@ import { postVideoInformation, selectStatus, selectError } from '../redux/workfl
 
 import { PageButton } from './Finish'
 
-import './../i18n/config';
 import { useTranslation } from 'react-i18next';
 import { AppDispatch } from "../redux/store";
 import { postMetadata, selectPostError, selectPostStatus, setHasChanges as metadataSetHasChanges,
@@ -85,11 +84,11 @@ const Save : React.FC<{}> = () => {
       {render()}
       <div css={errorBoxStyle(postWorkflowStatus === "failed", theme)} role="alert">
         <span>{t("various.error-text")}</span><br />
-        {postError ? t("various.error-details-text", {errorMessage: postError}) : t("various.error-noDetails-text")}<br />
+        {postError ? t("various.error-details-text", {errorMessage: postError}) : t("various.error-text")}<br />
       </div>
       <div css={errorBoxStyle(postMetadataStatus === "failed", theme)} role="alert">
         <span>{t("various.error-text")}</span><br />
-        {postMetadataError ? t("various.error-details-text", {errorMessage: postMetadataError}) : t("various.error-noDetails-text")}<br />
+        {postMetadataError ? t("various.error-details-text", {errorMessage: postMetadataError}) : t("various.error-text")}<br />
       </div>
     </div>
   );

--- a/src/main/SubtitleSelect.tsx
+++ b/src/main/SubtitleSelect.tsx
@@ -199,7 +199,7 @@ const SubtitleAddButton: React.FC<{languages: {subFlavor: string, title: string}
     <ThemedTooltip title={isPlusDisplay ? t("subtitles.createSubtitleButton-tooltip") : ""}>
       <div css={[basicButtonStyle(theme), tileButtonStyle(theme), !isPlusDisplay && disableButtonAnimation]}
         role="button" tabIndex={0}
-        aria-label={isPlusDisplay ? t("subtitles.createSubtitleButton-tooltip") : t("createSubtitleButton-clicked-tooltip-aria")}
+        aria-label={isPlusDisplay ? t("subtitles.createSubtitleButton-tooltip") : t("subtitles.createSubtitleButton-clicked-tooltip-aria")}
         onClick={ () => setIsPlusDisplay(false) }
         onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) => { if (event.key === " " || event.key === "Enter") {
           setIsPlusDisplay(false)

--- a/src/main/SubtitleTimeline.tsx
+++ b/src/main/SubtitleTimeline.tsx
@@ -24,7 +24,7 @@ import { scrubberKeyMap } from "../globalKeys";
 import ScrollContainer, { ScrollEvent } from "react-indiana-drag-scroll";
 import { selectTheme } from "../redux/themeSlice";
 import { ThemedTooltip } from "./Tooltip";
-import { t } from "i18next";
+import { useTranslation } from "react-i18next";
 
 /**
  * Copy-paste of the timeline in Video.tsx, so that we can make some small adjustments,
@@ -32,6 +32,7 @@ import { t } from "i18next";
  */
  const SubtitleTimeline: React.FC<{}> = () => {
 
+  const { t } = useTranslation();
   const theme = useSelector(selectTheme)
 
   // Init redux variables

--- a/src/main/TheEnd.tsx
+++ b/src/main/TheEnd.tsx
@@ -9,7 +9,6 @@ import { useSelector } from 'react-redux';
 import { selectEndState } from '../redux/endSlice'
 import { basicButtonStyle, flexGapReplacementStyle, navigationButtonStyle } from "../cssStyles";
 
-import './../i18n/config';
 import { useTranslation } from 'react-i18next';
 import { selectTheme } from "../redux/themeSlice";
 import { ThemedTooltip } from "./Tooltip";

--- a/src/main/Thumbnail.tsx
+++ b/src/main/Thumbnail.tsx
@@ -2,7 +2,6 @@ import { css } from "@emotion/react";
 import { IconProp } from "@fortawesome/fontawesome-svg-core";
 import { faCamera, faCopy, faInfoCircle, faTimesCircle, faUpload } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { t } from "i18next";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
@@ -472,6 +471,7 @@ const ThumbnailTableSingleRow: React.FC<{
   uploadCallback: any,
   discard: any,
 }> = ({track, index, inputRefs, generate, upload, uploadCallback, discard}) => {
+  const { t } = useTranslation();
 
   return (
     <div key={index} css={thumbnailTableRowStyle}>

--- a/src/main/Timeline.tsx
+++ b/src/main/Timeline.tsx
@@ -20,7 +20,6 @@ import { convertMsToReadableString } from '../util/utilityFunctions';
 import { GlobalHotKeys } from 'react-hotkeys';
 import { scrubberKeyMap } from '../globalKeys';
 
-import './../i18n/config';
 import { useTranslation } from 'react-i18next';
 import { ActionCreatorWithPayload } from '@reduxjs/toolkit';
 import { RootState } from '../redux/store';

--- a/src/main/Video.tsx
+++ b/src/main/Video.tsx
@@ -22,7 +22,6 @@ import { basicButtonStyle, flexGapReplacementStyle, titleStyle, titleStyleBold }
 import { GlobalHotKeys, KeyMapOptions } from 'react-hotkeys';
 import { videoPlayerKeyMap } from "../globalKeys";
 import { SyntheticEvent } from "react";
-import './../i18n/config';
 import { useTranslation } from 'react-i18next';
 import { selectTitleFromEpisodeDc } from "../redux/metadataSlice";
 import { setError } from "../redux/errorSlice";

--- a/src/main/WorkflowConfiguration.tsx
+++ b/src/main/WorkflowConfiguration.tsx
@@ -14,7 +14,6 @@ import { postVideoInformationWithWorkflow, selectStatus, selectError } from '../
 import { PageButton } from './Finish'
 import { setEnd } from "../redux/endSlice";
 
-import './../i18n/config';
 import { useTranslation } from 'react-i18next';
 import { postMetadata, selectPostError, selectPostStatus, setHasChanges as metadataSetHasChanges } from "../redux/metadataSlice";
 import { AppDispatch } from "../redux/store";
@@ -56,11 +55,11 @@ const WorkflowConfiguration : React.FC<{}> = () => {
       </div>
       <div css={errorBoxStyle(postAndProcessWorkflowStatus === "failed", theme)} role="alert">
         <span>{t("various.error-text")}</span><br />
-        {postAndProcessError ? t("various.error-details-text", {errorMessage: postAndProcessError}) : t("various.error-noDetails-text")}<br/>
+        {postAndProcessError ? t("various.error-details-text", {errorMessage: postAndProcessError}) : t("various.error-text")}<br/>
       </div>
       <div css={errorBoxStyle(postMetadataStatus === "failed", theme)} role="alert">
         <span>{t("various.error-text")}</span><br />
-        {postMetadataError ? t("various.error-details-text", {errorMessage: postMetadataError}) : t("various.error-noDetails-text")}<br />
+        {postMetadataError ? t("various.error-details-text", {errorMessage: postMetadataError}) : t("various.error-text")}<br />
       </div>
     </div>
   );

--- a/src/main/WorkflowSelection.tsx
+++ b/src/main/WorkflowSelection.tsx
@@ -16,7 +16,6 @@ import { httpRequestState, Workflow } from "../types";
 import { SaveButton } from "./Save";
 import { EmotionJSX } from "@emotion/react/types/jsx-namespace";
 
-import './../i18n/config';
 import { useTranslation } from 'react-i18next';
 import { Trans } from "react-i18next";
 import { FormControlLabel, Radio, RadioGroup, withStyles } from "@material-ui/core";
@@ -97,7 +96,7 @@ const WorkflowSelection : React.FC<{}> = () => {
         </div>
         <div css={errorBoxStyle(errorStatus === "failed", theme)} role="alert">
           <span>{t("various.error-text")}</span><br />
-          {errorMessage ? t("various.error-details-text", {errorMessage: postAndProcessError}) : t("various.error-noDetails-text")}<br/>
+          {errorMessage ? t("various.error-details-text", {errorMessage: postAndProcessError}) : t("various.error-text")}<br/>
         </div>
       </div>
     );


### PR DESCRIPTION
Adds type checking to our translation library.  This will help us avoid using translation strings that do not exist.

I've use "TFuncKey" as the type for cases where we pass a variable string  instead of a literal. This could arguably be improved upon in the future.

Also some related cleanup.

Closes #977 