### PR TITLE
Load locally if possible

### DIFF
--- a/editor-settings.toml
+++ b/editor-settings.toml
@@ -157,3 +157,11 @@
 # Type: string | undefined
 # Default: undefined
 #password =
+
+# Replace media package URLs with local URLs if possible.
+# This is done only if:
+# - Opencast indicates that the files are available locally
+# - Opencast URL has not been overwritten
+# Type: boolean
+# Default: true
+#local =

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,6 +38,7 @@ interface iSettings {
     url: string,
     name: string | undefined,
     password: string | undefined,
+    local: boolean,
   },
   metadata: {
     show: boolean,
@@ -72,6 +73,7 @@ var defaultSettings: iSettings = {
     url: window.location.origin,
     name: undefined,
     password: undefined,
+    local: true,
   },
   metadata: {
     show: true,
@@ -140,6 +142,9 @@ export const init = async () => {
 
   // Combine results
   settings = merge.all([defaultSettings, configFileSettings, urlParameterSettings]) as iSettings;
+
+  // Prepare local setting to avoid complicated checks later
+  settings.opencast.local = settings.opencast.local && settings.opencast.url === window.location.origin;
 
   // Configure hotkeys
   configure({

--- a/src/redux/videoSlice.ts
+++ b/src/redux/videoSlice.ts
@@ -195,7 +195,16 @@ const videoSlice = createSlice({
           state.errorReason = 'workflowActive'
           state.error = "This event is being processed. Please wait until the process is finished."
         }
-        state.tracks = action.payload.tracks.sort((a: { thumbnailPriority: number; },b: { thumbnailPriority: number; }) => a.thumbnailPriority - b.thumbnailPriority)
+        state.tracks = action.payload.tracks
+          .sort((a: { thumbnailPriority: number; },b: { thumbnailPriority: number; }) => {
+            return a.thumbnailPriority - b.thumbnailPriority
+          }).map((track: Track) => {
+            if (action.payload.local && settings.opencast.local) {
+              console.debug('Replacing track URL')
+              track.uri = track.uri.replace(/https?:\/\/[^/]*/g, window.location.origin )
+            }
+            return track
+          })
         const videos = state.tracks.filter((track: Track) => track.video_stream.available === true)
         // eslint-disable-next-line no-sequences
         state.videoURLs = videos.reduce((a: string[], o: { uri: string }) => (a.push(o.uri), a), [])


### PR DESCRIPTION
This patch allows the editor to load files from the local server if possible (indicated by Opencast). This means that, for example, with the default configuration, files are no longer loaded from the admin server when the editor is accessed on presentation, causing authentication problems.