### PR TITLE
Update reduxjs/toolkit to 1.9.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@mui/material": "^5.11.15",
         "@mui/styles": "^5.11.13",
         "@mui/x-date-pickers": "^5.0.20",
-        "@reduxjs/toolkit": "^1.8.5",
+        "@reduxjs/toolkit": "^1.9.3",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^12.1.5",
         "@testing-library/user-event": "^14.4.3",
@@ -4647,14 +4647,14 @@
       }
     },
     "node_modules/@reduxjs/toolkit": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.6.tgz",
-      "integrity": "sha512-4Ia/Loc6WLmdSOzi7k5ff7dLK8CgG2b8aqpLsCAJhazAzGdp//YBUSaj0ceW6a3kDBDNRrq5CRwyCS0wBiL1ig==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.3.tgz",
+      "integrity": "sha512-GU2TNBQVofL09VGmuSioNPQIu6Ml0YLf4EJhgj0AvBadRlCGzUWet8372LjvO4fqKZF2vH1xU0htAa7BrK9pZg==",
       "dependencies": {
-        "immer": "^9.0.7",
-        "redux": "^4.1.2",
-        "redux-thunk": "^2.4.1",
-        "reselect": "^4.1.5"
+        "immer": "^9.0.16",
+        "redux": "^4.2.0",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.7"
       },
       "peerDependencies": {
         "react": "^16.9.0 || ^17.0.0 || ^18",
@@ -10525,9 +10525,9 @@
       }
     },
     "node_modules/immer": {
-      "version": "9.0.15",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.15.tgz",
-      "integrity": "sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ==",
+      "version": "9.0.21",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
+      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -17818,9 +17818,9 @@
       }
     },
     "node_modules/redux-thunk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
-      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
       "peerDependencies": {
         "redux": "^4"
       }
@@ -17968,9 +17968,9 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/reselect": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.6.tgz",
-      "integrity": "sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ=="
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.7.tgz",
+      "integrity": "sha512-Zu1xbUt3/OPwsXL46hvOOoQrap2azE7ZQbokq61BQfiXvhewsKDwhMeZjTX9sX0nvw1t/U5Audyn1I9P/m9z0A=="
     },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
@@ -23880,14 +23880,14 @@
       }
     },
     "@reduxjs/toolkit": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.6.tgz",
-      "integrity": "sha512-4Ia/Loc6WLmdSOzi7k5ff7dLK8CgG2b8aqpLsCAJhazAzGdp//YBUSaj0ceW6a3kDBDNRrq5CRwyCS0wBiL1ig==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.3.tgz",
+      "integrity": "sha512-GU2TNBQVofL09VGmuSioNPQIu6Ml0YLf4EJhgj0AvBadRlCGzUWet8372LjvO4fqKZF2vH1xU0htAa7BrK9pZg==",
       "requires": {
-        "immer": "^9.0.7",
-        "redux": "^4.1.2",
-        "redux-thunk": "^2.4.1",
-        "reselect": "^4.1.5"
+        "immer": "^9.0.16",
+        "redux": "^4.2.0",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.7"
       }
     },
     "@rollup/plugin-babel": {
@@ -28213,9 +28213,9 @@
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
     },
     "immer": {
-      "version": "9.0.15",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.15.tgz",
-      "integrity": "sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ=="
+      "version": "9.0.21",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
+      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -33398,9 +33398,9 @@
       }
     },
     "redux-thunk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
-      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
       "requires": {}
     },
     "regenerate": {
@@ -33515,9 +33515,9 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "reselect": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.6.tgz",
-      "integrity": "sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ=="
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.7.tgz",
+      "integrity": "sha512-Zu1xbUt3/OPwsXL46hvOOoQrap2azE7ZQbokq61BQfiXvhewsKDwhMeZjTX9sX0nvw1t/U5Audyn1I9P/m9z0A=="
     },
     "resize-observer-polyfill": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@mui/material": "^5.11.15",
     "@mui/styles": "^5.11.13",
     "@mui/x-date-pickers": "^5.0.20",
-    "@reduxjs/toolkit": "^1.8.5",
+    "@reduxjs/toolkit": "^1.9.3",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^12.1.5",
     "@testing-library/user-event": "^14.4.3",

--- a/src/main/Metadata.tsx
+++ b/src/main/Metadata.tsx
@@ -362,7 +362,8 @@ const Metadata: React.FC<{}> = () => {
       if (catalogs[catalogIndex].fields[fieldIndex].id === fieldName) {
         // Update the field in the redux catalog
         dispatch(setFieldValue({catalogIndex: catalogIndex, fieldIndex: fieldIndex,
-          value: parseValue(catalogs[catalogIndex].fields[fieldIndex], value)}))
+          value: parseValue(catalogs[catalogIndex].fields[fieldIndex], value)
+        }))
         break
       }
     }
@@ -441,7 +442,8 @@ const Metadata: React.FC<{}> = () => {
           if (catalogs[catalogIndex].fields[fieldIndex].id === formFieldName) {
             // Update the field in the redux catalog
             dispatch(setFieldValue({catalogIndex: catalogIndex, fieldIndex: fieldIndex,
-              value: parseValue(catalogs[catalogIndex].fields[fieldIndex], values[formCatalogName][formFieldName])}))
+              value: parseValue(catalogs[catalogIndex].fields[fieldIndex], values[formCatalogName][formFieldName])
+            }))
             break
           }
         }

--- a/src/redux/metadataSlice.ts
+++ b/src/redux/metadataSlice.ts
@@ -99,11 +99,11 @@ const metadataSlice = createSlice({
   name: 'metadataState',
   initialState,
   reducers: {
-    setFieldValue: (state, action: any) => {
+    setFieldValue: (state, action: PayloadAction<{catalogIndex: number, fieldIndex: number, value: string}>) => {
       state.catalogs[action.payload.catalogIndex].fields[action.payload.fieldIndex].value = action.payload.value
       state.hasChanges = true
     },
-    setFieldReadonly: (state, action: any) => {
+    setFieldReadonly: (state, action: PayloadAction<{catalogIndex: number, fieldIndex: number, value: boolean}>) => {
       state.catalogs[action.payload.catalogIndex].fields[action.payload.fieldIndex].readOnly = action.payload.value
     },
     setHasChanges: (state, action: PayloadAction<metadata["hasChanges"]>) => {


### PR DESCRIPTION
Updates the dependency 'reduxjs/toolkit' to version 1.9.3. Fixes associated type errors by explicitely stating the types for certain CaseReducers.

Replaces #994 