### PR TITLE
Updates react-virtualized-auto-sizer to 1.0.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "react-scripts": "5.0.1",
         "react-select": "^5.7.0",
         "react-use": "^17.4.0",
-        "react-virtualized-auto-sizer": "^1.0.6",
+        "react-virtualized-auto-sizer": "^1.0.9",
         "react-window": "^1.8.8",
         "redux": "^4.2.1",
         "standardized-audio-context": "^25.3.41",
@@ -17710,12 +17710,9 @@
       }
     },
     "node_modules/react-virtualized-auto-sizer": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.7.tgz",
-      "integrity": "sha512-Mxi6lwOmjwIjC1X4gABXMJcKHsOo0xWl3E3ugOgufB8GJU+MqrtY35aBuvCYv/razQ1Vbp7h1gWJjGjoNN5pmA==",
-      "engines": {
-        "node": ">8.0.0"
-      },
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.11.tgz",
+      "integrity": "sha512-v2YlC4KCnjEF7V5KtxrHCy50vPhbL73BS1qNOXFYaaE1XGeRqZHrGP+F4BE0QDv2pP+f1t9twL1n5pRp5GPMkQ==",
       "peerDependencies": {
         "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc",
         "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc"
@@ -33311,9 +33308,9 @@
       }
     },
     "react-virtualized-auto-sizer": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.7.tgz",
-      "integrity": "sha512-Mxi6lwOmjwIjC1X4gABXMJcKHsOo0xWl3E3ugOgufB8GJU+MqrtY35aBuvCYv/razQ1Vbp7h1gWJjGjoNN5pmA==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.11.tgz",
+      "integrity": "sha512-v2YlC4KCnjEF7V5KtxrHCy50vPhbL73BS1qNOXFYaaE1XGeRqZHrGP+F4BE0QDv2pP+f1t9twL1n5pRp5GPMkQ==",
       "requires": {}
     },
     "react-window": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "react-scripts": "5.0.1",
     "react-select": "^5.7.0",
     "react-use": "^17.4.0",
-    "react-virtualized-auto-sizer": "^1.0.6",
+    "react-virtualized-auto-sizer": "^1.0.9",
     "react-window": "^1.8.8",
     "redux": "^4.2.1",
     "standardized-audio-context": "^25.3.41",

--- a/src/main/SubtitleListEditor.tsx
+++ b/src/main/SubtitleListEditor.tsx
@@ -117,12 +117,12 @@ const SubtitleListEditor : React.FC<{}> = () => {
       <AutoSizer>
         {({ height, width }) => (
           <VariableSizeList
-            height={height}
+            height={height ? height : 0}
             itemCount={subtitle !== undefined ? subtitle.length : 0}
             itemData={itemData}
             itemSize={(index) => segmentHeight}
             itemKey={(index, data) => data.items[index].idInternal}
-            width={width}
+            width={width ? width : 0}
             overscanCount={4}
             estimatedItemSize={calcEstimatedSize()}
             innerElementType={innerElementType}


### PR DESCRIPTION
Updates dependency 'react-virtualized-auto-sizer' to version 1.0.9.

Fixes an issue where the `height` and `width` provided by `AutoSizer` can now be undefined, which `VariableSizeList` does not accept.

Also is it just me or does adding new fields to the list in the subtitle editor feel slower with this update?

Replaces #1024 