### PR TITLE
Update react-virtualized-auto-resizer to 1.0.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "react-resizable": "^3.0.5",
         "react-scripts": "5.0.1",
         "react-select": "^5.7.3",
-        "react-virtualized-auto-sizer": "^1.0.15",
+        "react-virtualized-auto-sizer": "^1.0.20",
         "react-window": "^1.8.9",
         "redux": "^4.2.1",
         "standardized-audio-context": "^25.3.50",
@@ -17114,9 +17114,9 @@
       }
     },
     "node_modules/react-virtualized-auto-sizer": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.15.tgz",
-      "integrity": "sha512-01yhkssgHShMiu5W8k+86kgl8lutpl+Uef9KP4wrozXnzZjxWIgj+cH8Qi064oQpKD8myn/JNMzp4tcZNQ3Avg==",
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.20.tgz",
+      "integrity": "sha512-OdIyHwj4S4wyhbKHOKM1wLSj/UDXm839Z3Cvfg2a9j+He6yDa6i5p0qQvEiCnyQlGO/HyfSnigQwuxvYalaAXA==",
       "peerDependencies": {
         "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc",
         "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc"
@@ -32098,9 +32098,9 @@
       }
     },
     "react-virtualized-auto-sizer": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.15.tgz",
-      "integrity": "sha512-01yhkssgHShMiu5W8k+86kgl8lutpl+Uef9KP4wrozXnzZjxWIgj+cH8Qi064oQpKD8myn/JNMzp4tcZNQ3Avg==",
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.20.tgz",
+      "integrity": "sha512-OdIyHwj4S4wyhbKHOKM1wLSj/UDXm839Z3Cvfg2a9j+He6yDa6i5p0qQvEiCnyQlGO/HyfSnigQwuxvYalaAXA==",
       "requires": {}
     },
     "react-window": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-resizable": "^3.0.5",
     "react-scripts": "5.0.1",
     "react-select": "^5.7.3",
-    "react-virtualized-auto-sizer": "^1.0.15",
+    "react-virtualized-auto-sizer": "^1.0.20",
     "react-window": "^1.8.9",
     "redux": "^4.2.1",
     "standardized-audio-context": "^25.3.50",

--- a/src/main/SubtitleListEditor.tsx
+++ b/src/main/SubtitleListEditor.tsx
@@ -115,7 +115,7 @@ const SubtitleListEditor : React.FC = () => {
   return (
     <div css={listStyle}>
       <AutoSizer>
-        {({ height, width }) => (
+        {({ height, width }: {height: string | number, width: string | number}) => (
           <VariableSizeList
             height={height ? height : 0}
             itemCount={subtitle !== undefined ? subtitle.length : 0}


### PR DESCRIPTION
Also fixes a non-typed object that blocked the update