### PR TITLE
Add callback url for integration (#1084)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,19 +65,20 @@ If an option can be specified both ways, the URL parameter will always take prec
 
 Options which are usually specified in the configuration file are documented in there as well. Metadata configuration options are only documented in the configuration file.
 
-| Option              | URL | File | Description
-| --------------------|-----|------|------------
-| id                  | ✓   | ✓    | Id of the event that the editor should open by default.
-| mediaPackageId      | ✓   | ✓    | Deprecated. Use `id` instead.
-| opencast.url        | ✗   | ✓    | URL of the opencast server to connect to.
-| opencast.name       | ✗   | ✓    | Opencast user to use. For demo purposes only.
-| opencast.password   | ✗   | ✓    | Password to use for authentication. For demo purposes only.
-| metadata.show       | ✓   | ✓    | Show metadata tab.
-| trackSelection.show | ✓   | ✓    | Show track selection tab.
-| thumbnail.show      | ✓   | ✓    | Show thumbnail tab. Demo only.
-| debug               | ✓   | ✗    | Enable internationalization debugging.
-| lng                 | ✓   | ✗    | Select a specific language. Use language codes like `de` or `en-US`.
-
+| Option                  | URL | File | Description                                                          |
+|-------------------------|-----|------|----------------------------------------------------------------------|
+| id                      | ✓   | ✓    | Id of the event that the editor should open by default.              |
+| mediaPackageId          | ✓   | ✓    | Deprecated. Use `id` instead.                                        |
+| allowedCallbackPrefixes | ✗   | ✓    | Allowed callback prefixes in callback url.                           |
+| callbackUrl             | ✓   | ✓    | Callback url to go back after finish.                                |
+| opencast.url            | ✗   | ✓    | URL of the opencast server to connect to.                            |
+| opencast.name           | ✗   | ✓    | Opencast user to use. For demo purposes only.                        |
+| opencast.password       | ✗   | ✓    | Password to use for authentication. For demo purposes only.          |
+| metadata.show           | ✓   | ✓    | Show metadata tab.                                                   |
+| trackSelection.show     | ✓   | ✓    | Show track selection tab.                                            |
+| thumbnail.show          | ✓   | ✓    | Show thumbnail tab. Demo only.                                       |
+| debug                   | ✓   | ✗    | Enable internationalization debugging.                               |
+| lng                     | ✓   | ✗    | Select a specific language. Use language codes like `de` or `en-US`. |
 
 How to cut a release for Opencast
 ---------------------------------

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Options which are usually specified in the configuration file are documented in 
 | mediaPackageId          | ✓   | ✓    | Deprecated. Use `id` instead.                                        |
 | allowedCallbackPrefixes | ✗   | ✓    | Allowed callback prefixes in callback url.                           |
 | callbackUrl             | ✓   | ✓    | Callback url to go back after finish.                                |
+| callbackSystem          | ✓   | ✓    | Callback system name to go back to.                                  |
 | opencast.url            | ✗   | ✓    | URL of the opencast server to connect to.                            |
 | opencast.name           | ✗   | ✓    | Opencast user to use. For demo purposes only.                        |
 | opencast.password       | ✗   | ✓    | Password to use for authentication. For demo purposes only.          |

--- a/editor-settings.toml
+++ b/editor-settings.toml
@@ -9,6 +9,23 @@
 
 
 ####
+# General Settings
+##
+
+# Allowed prefixes in callback urls to prevent malicious urls
+# If empty, no callback url is allowed
+# Type: string[]
+# Default: []
+#allowedCallbackDomains = []
+
+# Url to go back after finishing editing
+# If undefined, no return link will be shown on the end pages
+# Type: string | undefined
+# Default: undefined
+#callbackUrl =
+
+
+####
 # Metadata
 ##
 

--- a/editor-settings.toml
+++ b/editor-settings.toml
@@ -24,6 +24,12 @@
 # Default: undefined
 #callbackUrl =
 
+# Name of system to go back to
+# If undefined, a generic system name is used instead of a speficic name
+# Type: string | undefined
+# Default: undefined
+#callbackSystem =
+
 
 ####
 # Metadata

--- a/editor-settings.toml
+++ b/editor-settings.toml
@@ -16,7 +16,7 @@
 # If empty, no callback url is allowed
 # Type: string[]
 # Default: []
-#allowedCallbackDomains = []
+#allowedCallbackPrefixes = []
 
 # Url to go back after finishing editing
 # If undefined, no return link will be shown on the end pages

--- a/public/editor-settings.toml
+++ b/public/editor-settings.toml
@@ -11,6 +11,10 @@
 # Pick a default event identifier which should be on develop.opencast.org
 id = 'ID-dual-stream-demo'
 
+# Callback to develop.opencast.org
+allowedCallbackPrefixes = ["https://develop.opencast.org"]
+callbackUrl = "https://develop.opencast.org"
+
 [opencast]
 # Connect to develop.opencast.org and use the default demo user
 url = 'https://develop.opencast.org'

--- a/public/editor-settings.toml
+++ b/public/editor-settings.toml
@@ -14,6 +14,7 @@ id = 'ID-dual-stream-demo'
 # Callback to develop.opencast.org
 allowedCallbackPrefixes = ["https://develop.opencast.org"]
 callbackUrl = "https://develop.opencast.org"
+callbackSystem = "OPENCAST"
 
 [opencast]
 # Connect to develop.opencast.org and use the default demo user

--- a/src/config.ts
+++ b/src/config.ts
@@ -43,6 +43,7 @@ interface iSettings {
   id: string | undefined,
   allowedCallbackPrefixes: string[],
   callbackUrl: string | undefined,
+  callbackSystem: string | undefined,
   opencast: {
     url: string,
     name: string | undefined,
@@ -80,6 +81,7 @@ const defaultSettings: iSettings = {
   id: undefined,
   allowedCallbackPrefixes: [],
   callbackUrl: undefined,
+  callbackSystem: undefined,
   opencast: {
     url: window.location.origin,
     name: undefined,
@@ -389,6 +391,7 @@ const SCHEMA = {
   id: types.string,
   allowedCallbackPrefixes: types.array,
   callbackUrl: types.string,
+  callbackSystem: types.string,
   opencast: {
     url: types.string,
     name: types.string,

--- a/src/config.ts
+++ b/src/config.ts
@@ -140,7 +140,7 @@ export const init = async () => {
     // Create empty objects for full path (if the key contains '.') and set
     // the value at the end.
     let obj : {[k: string]: any} = rawUrlSettings;
-    if (key.startsWith('opencast.') || key === 'allowedCallbackDomains') {
+    if (key.startsWith('opencast.') || key === 'allowedCallbackPrefixes') {
       return;
     }
 

--- a/src/i18n/locales/de-DE.json
+++ b/src/i18n/locales/de-DE.json
@@ -202,7 +202,8 @@
         "error-details-text": "Details: {{errorMessage}}\n",
         "error-text": "Ein Fehler ist aufgetreten. Bitte versuchen Sie es später noch einmal.",
         "goBack-button": "Nein, zurück",
-        "callback-button": "Zurück zum vorigen System"
+        "callback-button-system": "Zurück zu {{system}}",
+        "callback-button-generic": "Zurück zum vorigen System"
     },
     "trackSelection": {
         "title": "Spur(en) für die Verarbeitung auswählen",

--- a/src/i18n/locales/de-DE.json
+++ b/src/i18n/locales/de-DE.json
@@ -201,7 +201,8 @@
     "various": {
         "error-details-text": "Details: {{errorMessage}}\n",
         "error-text": "Ein Fehler ist aufgetreten. Bitte versuchen Sie es später noch einmal.",
-        "goBack-button": "Nein, zurück"
+        "goBack-button": "Nein, zurück",
+        "callback-button": "Zurück zum vorigen System"
     },
     "trackSelection": {
         "title": "Spur(en) für die Verarbeitung auswählen",

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -216,7 +216,8 @@
     "various": {
       "error-details-text": "Details: {{errorMessage}}\n",
       "error-text": "An error has occurred. Please wait a bit and try again.",
-      "goBack-button": "No, take me back"
+      "goBack-button": "No, take me back",
+      "callback-button": "Back to previous system"
     },
 
     "trackSelection": {

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -217,7 +217,8 @@
       "error-details-text": "Details: {{errorMessage}}\n",
       "error-text": "An error has occurred. Please wait a bit and try again.",
       "goBack-button": "No, take me back",
-      "callback-button": "Back to previous system"
+      "callback-button-system": "Back to {{system}}",
+      "callback-button-generic": "Back to previous system"
     },
 
     "trackSelection": {

--- a/src/main/Finish.tsx
+++ b/src/main/Finish.tsx
@@ -113,7 +113,7 @@ export const CallbackButton : React.FC = () => {
             openCallbackUrl()
           } }}>
           <LuDoorOpen />
-          <span>{t("various.callback-button")}</span>
+          <span>{settings.callbackSystem ? t("various.callback-button-system", {system: settings.callbackSystem}) : t("various.callback-button-generic")}</span>
         </div>
       }
     </>

--- a/src/main/Finish.tsx
+++ b/src/main/Finish.tsx
@@ -7,13 +7,15 @@ import WorkflowSelection from "./WorkflowSelection";
 import WorkflowConfiguration from "./WorkflowConfiguration";
 
 import { css } from '@emotion/react'
-import { basicButtonStyle } from '../cssStyles'
+import { basicButtonStyle, navigationButtonStyle } from '../cssStyles'
 
 import { IconType } from "react-icons";
 
 import { useDispatch, useSelector } from 'react-redux';
 import { selectPageNumber, setPageNumber } from '../redux/finishSlice';
 import { useTheme } from "../themes";
+import { settings } from "../config";
+import { useTranslation } from "react-i18next";
 
 /**
  * Displays a menu for selecting what should be done with the current changes
@@ -83,6 +85,36 @@ export const PageButton : React.FC<{pageNumber: number, label: string, Icon: Ico
       <Icon />
       <span>{label}</span>
     </div>
+  );
+}
+
+/**
+ * Takes you back to the callback url resource
+ */
+export const CallbackButton : React.FC = () => {
+
+  const { t } = useTranslation();
+
+  const theme = useSelector(selectTheme);
+
+  const openCallbackUrl = () => {
+    window.open(settings.callbackUrl, "_self");
+  }
+
+  return (
+    <>
+      {settings.callbackUrl !== undefined &&
+        <div css={[basicButtonStyle(theme), navigationButtonStyle(theme)]}
+          role="button" tabIndex={0}
+          onClick={openCallbackUrl}
+          onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) => { if (event.key === " " || event.key === "Enter") {
+            openCallbackUrl()
+          } }}>
+          <FontAwesomeIcon icon={faRightFromBracket} size="1x" />
+          <span>{t("various.callback-button")}</span>
+        </div>
+      }
+    </>
   );
 }
 

--- a/src/main/Finish.tsx
+++ b/src/main/Finish.tsx
@@ -6,6 +6,8 @@ import Discard from "./Discard"
 import WorkflowSelection from "./WorkflowSelection";
 import WorkflowConfiguration from "./WorkflowConfiguration";
 
+import { LuDoorOpen} from "react-icons/lu";
+
 import { css } from '@emotion/react'
 import { basicButtonStyle, navigationButtonStyle } from '../cssStyles'
 
@@ -95,7 +97,7 @@ export const CallbackButton : React.FC = () => {
 
   const { t } = useTranslation();
 
-  const theme = useSelector(selectTheme);
+  const theme = useTheme();
 
   const openCallbackUrl = () => {
     window.open(settings.callbackUrl, "_self");
@@ -110,7 +112,7 @@ export const CallbackButton : React.FC = () => {
           onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) => { if (event.key === " " || event.key === "Enter") {
             openCallbackUrl()
           } }}>
-          <FontAwesomeIcon icon={faRightFromBracket} size="1x" />
+          <LuDoorOpen />
           <span>{t("various.callback-button")}</span>
         </div>
       }

--- a/src/main/Save.tsx
+++ b/src/main/Save.tsx
@@ -11,7 +11,7 @@ import { selectFinishState } from '../redux/finishSlice'
 import { selectHasChanges, selectSegments, selectTracks, setHasChanges as videoSetHasChanges } from '../redux/videoSlice'
 import { postVideoInformation, selectStatus, selectError } from '../redux/workflowPostSlice'
 
-import { PageButton } from './Finish'
+import { CallbackButton, PageButton } from './Finish'
 
 import { useTranslation } from 'react-i18next';
 import { AppDispatch } from "../redux/store";
@@ -58,6 +58,7 @@ const Save : React.FC = () => {
         <>
           <LuCheckCircle css={{fontSize: 80}}/>
           <div>{t("save.success-text")}</div>
+          <CallbackButton />
         </>
       )
     // Pre save

--- a/src/main/TheEnd.tsx
+++ b/src/main/TheEnd.tsx
@@ -42,12 +42,20 @@ const TheEnd : React.FC = () => {
     ...(flexGapReplacementStyle(20, false)),
   })
 
+  const restartOrBackStyle = css({
+    display: "flex",
+    flexDirection: 'row',
+    ...(flexGapReplacementStyle(20, false)),
+  })
+
   return (
     <div css={theEndStyle}>
       {endState === 'discarded' ? <LuXCircle css={{fontSize: 80}}/> : <LuCheckCircle css={{fontSize: 80}}/> }
       <div>{text()}</div>
-      {(endState === 'discarded') && <StartOverButton />}
-      <CallbackButton />
+      <div css={restartOrBackStyle}>
+        <CallbackButton />
+        {(endState === 'discarded') && <StartOverButton />}
+      </div>
     </div>
   );
 }

--- a/src/main/TheEnd.tsx
+++ b/src/main/TheEnd.tsx
@@ -11,6 +11,7 @@ import { basicButtonStyle, flexGapReplacementStyle, navigationButtonStyle } from
 import { useTranslation } from 'react-i18next';
 import { useTheme } from "../themes";
 import { ThemedTooltip } from "./Tooltip";
+import { CallbackButton } from "./Finish";
 
 /**
  * This page is to be displayed when the user is "done" with the editor
@@ -46,6 +47,7 @@ const TheEnd : React.FC = () => {
       {endState === 'discarded' ? <LuXCircle css={{fontSize: 80}}/> : <LuCheckCircle css={{fontSize: 80}}/> }
       <div>{text()}</div>
       {(endState === 'discarded') && <StartOverButton />}
+      <CallbackButton />
     </div>
   );
 }


### PR DESCRIPTION
After finishing the editing, the user can now navigate back to the calling system using a button. For this, the integrating system can pass a `callbackUrl` url parameter to provide a return link. In the editor settings, the prefixes of the allowed callback urls must be provided in the `allowedCallbackPrefixes` option to prevent malicious callback urls.