### PR TITLE
Bump appkit version for high contrast borders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@fontsource-variable/roboto-flex": "^5.0.3",
         "@iarna/toml": "^2.2.5",
         "@mui/material": "^5.14.7",
-        "@opencast/appkit": "^0.2.0",
+        "@opencast/appkit": "^0.2.1",
         "@reduxjs/toolkit": "^1.9.5",
         "@testing-library/jest-dom": "^6.1.2",
         "@types/iarna__toml": "^2.0.2",
@@ -3886,9 +3886,9 @@
       }
     },
     "node_modules/@opencast/appkit": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@opencast/appkit/-/appkit-0.2.0.tgz",
-      "integrity": "sha512-hRds2XYZBzVOWBaXnLrIn7ophXcFWb0NsfUTOrtfhONu6tdQqG288SS2dhrGCVhq8OBqwah8yAnCNDToHGzx9g==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@opencast/appkit/-/appkit-0.2.1.tgz",
+      "integrity": "sha512-G8tpq52kFbA/ZiPYXhrWi5METuUqNWvsQ1WISvOnK1TjedHiOpsG+tukH570546Lal5KA0lgCb26Lo4lQ6rB+g==",
       "peerDependencies": {
         "@emotion/react": "^11.11.1",
         "@floating-ui/react": "^0.24.3",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@fontsource-variable/roboto-flex": "^5.0.3",
     "@iarna/toml": "^2.2.5",
     "@mui/material": "^5.14.7",
-    "@opencast/appkit": "^0.2.0",
+    "@opencast/appkit": "^0.2.1",
     "@reduxjs/toolkit": "^1.9.5",
     "@testing-library/jest-dom": "^6.1.2",
     "@types/iarna__toml": "^2.0.2",


### PR DESCRIPTION
Bumps the version of `@opencast/appkit` to 0.2.1,
which adds visible borders around the language and appearance dropdowns in high contrast mode.

Resolves #1156.