### PR TITLE
Fix subtitles not being saved to Opencast

### DIFF
--- a/src/redux/workflowPostAndProcessSlice.ts
+++ b/src/redux/workflowPostAndProcessSlice.ts
@@ -17,7 +17,12 @@ export const postVideoInformationWithWorkflow = createAsyncThunk('video/postVide
   }
 
   const response = await client.post(`${settings.opencast.url}/editor/${settings.id}/edit.json`,
-    { segments: convertSegments(argument.segments), tracks: argument.tracks, workflows: argument.workflow }
+    {
+      segments: convertSegments(argument.segments),
+      tracks: argument.tracks,
+      subtitles: argument.subtitles,
+      workflows: argument.workflow
+    }
   )
   return response
 })

--- a/src/redux/workflowPostSlice.ts
+++ b/src/redux/workflowPostSlice.ts
@@ -15,7 +15,11 @@ export const postVideoInformation = createAsyncThunk('video/postVideoInformation
   }
 
   const response = await client.post(`${settings.opencast.url}/editor/${settings.id}/edit.json`,
-    { segments: convertSegments(argument.segments), tracks: argument.tracks, subtitles: argument.subtitles }
+    {
+      segments: convertSegments(argument.segments),
+      tracks: argument.tracks,
+      subtitles: argument.subtitles
+    }
   )
   return response
 })


### PR DESCRIPTION
Fixes #1161.

Turns out the post request for starting processing in Opencast simply did not include the (changes to) subtitles. Now it does.