### PR TITLE
Fix #1186, incorrect color of btn icons on hover

### DIFF
--- a/src/cssStyles.tsx
+++ b/src/cssStyles.tsx
@@ -436,10 +436,9 @@ export const spinningStyle = css({
   })}`,
 })
 
-export const customIconStyle = (theme: Theme) => css(({
+export const customIconStyle = css(({
   maxWidth: '16px',
-  height: 'auto',
-  color: theme.text,
+  height: 'auto'
 }))
 
 export const videosStyle = (theme: Theme) => css(({

--- a/src/main/CuttingActions.tsx
+++ b/src/main/CuttingActions.tsx
@@ -174,7 +174,7 @@ const MarkAsDeletedButton : React.FC<markAsDeleteButtonInterface> = ({actionHand
           actionHandler(action)
         } }}
       >
-        {isCurrentSegmentAlive ? <LuTrash /> : <TrashRestore css={customIconStyle(theme)} /> }
+        {isCurrentSegmentAlive ? <LuTrash /> : <TrashRestore css={customIconStyle} /> }
         <div>{isCurrentSegmentAlive ? t('cuttingActions.delete-button') : t("cuttingActions.restore-button")}</div>
       </div>
     </ThemedTooltip>

--- a/src/main/TrackSelection.tsx
+++ b/src/main/TrackSelection.tsx
@@ -188,7 +188,7 @@ const SelectButton : React.FC<selectButtonInterface> = ({handler, text, Icon, to
         aria-label={tooltip}
         onClick={clickHandler}
         onKeyDown={keyHandler} >
-        <Icon css={customIconStyle(theme)}/>
+        <Icon css={customIconStyle}/>
         <div>{ text }</div>
       </div>
     </ThemedTooltip>


### PR DESCRIPTION
Fixes #1186 

color property of the icon-class is overriding the color property of button-class on hover.