### PR TITLE
Don't show certain thumbnail buttons for single track

### DIFF
--- a/src/main/Thumbnail.tsx
+++ b/src/main/Thumbnail.tsx
@@ -174,7 +174,9 @@ const ThumbnailTable : React.FC<{
       )
     } else {
       return (<>
-        <AffectAllRow tracks={videoTracks} generate={generate}/>
+        { videoTracks.length > 1 &&
+          <AffectAllRow tracks={videoTracks} generate={generate}/>
+        }
         <div css={thumbnailTableStyle}>
           {videoTracks.map((track: Track, index: number) => (
             <ThumbnailTableRow
@@ -362,15 +364,19 @@ const ThumbnailButtons : React.FC<{
         aria-hidden="true"
       />
       <div css={verticalLineStyle} />
-      <ThumbnailButton
-        handler={() => { setForOtherThumbnails(track.thumbnailUri) }}
-        text={t('thumbnail.buttonUseForOtherThumbnails')}
-        tooltipText={t('thumbnail.buttonUseForOtherThumbnails-tooltip')}
-        ariaLabel={t('thumbnail.buttonUseForOtherThumbnails-tooltip-aria')}
-        Icon={LuCopy}
-        active={(track.thumbnailUri && track.thumbnailUri.startsWith("data") ? true : false)}
-      />
-      <div css={verticalLineStyle} />
+      { tracks.length > 1 &&
+        <>
+          <ThumbnailButton
+            handler={() => { setForOtherThumbnails(track.thumbnailUri) }}
+            text={t('thumbnail.buttonUseForOtherThumbnails')}
+            tooltipText={t('thumbnail.buttonUseForOtherThumbnails-tooltip')}
+            ariaLabel={t('thumbnail.buttonUseForOtherThumbnails-tooltip-aria')}
+            Icon={LuCopy}
+            active={(track.thumbnailUri && track.thumbnailUri.startsWith("data") ? true : false)}
+          />
+          <div css={verticalLineStyle} />
+        </>
+      }
       <ThumbnailButton
         handler={() => { discard(track.id) }}
         text={t('thumbnail.buttonDiscard')}


### PR DESCRIPTION
The "Generate All" and "Use for all tracks" buttons in the thumbnail view don't really serve a purpose when there is only one track. "Generate All" does the same thing as "Generate", and "Use for all tracks" does straight up nothing. Therefore, we might as well not display them if there is but a single track.

Fixes  #1206.