### PR TITLE
Thumbnail make boxes same size

### DIFF
--- a/src/main/Thumbnail.tsx
+++ b/src/main/Thumbnail.tsx
@@ -106,7 +106,8 @@ const Thumbnail : React.FC = () => {
         discard={discardThumbnail}
       />
       <div css={bottomStyle}>
-        <VideoPlayers refs={generateRefs} widthInPercent={100}/>
+        {/* use maxHeightInPixel to make video players the same size*/}
+        <VideoPlayers refs={generateRefs} widthInPercent={100} maxHeightInPixel={376}/>
         <div css={videosStyle(theme)}>
           <Timeline
             timelineHeight={125}

--- a/src/main/Thumbnail.tsx
+++ b/src/main/Thumbnail.tsx
@@ -101,6 +101,7 @@ const Thumbnail : React.FC = () => {
       <div css={[titleStyle(theme), titleStyleBold(theme)]}>{t('thumbnail.title')}</div>
       <ThumbnailTable
         inputRefs={inputRefs}
+        generateRefs={generateRefs}
         generate={generate}
         upload={upload}
         uploadCallback={uploadCallback}
@@ -108,7 +109,7 @@ const Thumbnail : React.FC = () => {
       />
       <div css={bottomStyle}>
         {/* use maxHeightInPixel to make video players the same size*/}
-        <VideoPlayers refs={generateRefs} widthInPercent={100} maxHeightInPixel={376}/>
+        <VideoPlayers refs={generateRefs} widthInPercent={100} maxHeightInPixel={420}/>
         <div css={videosStyle(theme)}>
           <Timeline
             timelineHeight={125}
@@ -141,16 +142,18 @@ const Thumbnail : React.FC = () => {
  */
 const ThumbnailTable : React.FC<{
   inputRefs: any,
+  generateRefs: React.MutableRefObject<any>,
   generate: any,
   upload: any,
   uploadCallback: any,
   discard: any,
-}> = ({inputRefs, generate, upload, uploadCallback, discard}) => {
+}> = ({inputRefs, generateRefs, generate, upload, uploadCallback, discard}) => {
 
   const videoTracks = useSelector(selectVideos)
 
   const thumbnailTableStyle = css({
     display: 'flex',
+    width: '100%',
     flexDirection: 'row',
     justifyContent: 'center',
     ...(flexGapReplacementStyle(10, false)),
@@ -184,6 +187,7 @@ const ThumbnailTable : React.FC<{
               track={track}
               index={index}
               inputRefs={inputRefs}
+              generateRef={generateRefs.current[index]}
               generate={generate}
               upload={upload}
               uploadCallback={uploadCallback}
@@ -209,14 +213,18 @@ const ThumbnailTableRow: React.FC<{
   track: Track,
   index: number,
   inputRefs: any,
+  generateRef: any,
   generate: any,
   upload: any,
   uploadCallback: any,
   discard: any,
-}> = ({track, index, inputRefs, generate, upload, uploadCallback, discard}) => {
+}> = ({track, index, inputRefs, generateRef, generate, upload, uploadCallback, discard}) => {
 
   const { t } = useTranslation()
   const theme = useTheme();
+
+  // The "+40" comes from padding that is not included in the "getWidth" function
+  const videoWidth = generateRef ? generateRef.getWidth() + 40 : undefined
 
   const renderPriority = (thumbnailPriority: number) => {
     if (isNaN(thumbnailPriority)) {
@@ -233,7 +241,7 @@ const ThumbnailTableRow: React.FC<{
   }
 
   return (
-    <div key={index} css={[backgroundBoxStyle(theme), thumbnailTableRowStyle]}>
+    <div key={index} css={[backgroundBoxStyle(theme), thumbnailTableRowStyle(videoWidth)]}>
       <div css={thumbnailTableRowTitleStyle}>
         {track.flavor.type + renderPriority(track.thumbnailPriority)}
       </div>
@@ -499,7 +507,7 @@ const ThumbnailTableSingleRow: React.FC<{
   const theme = useTheme();
 
   return (
-    <div key={index} css={[backgroundBoxStyle(theme), thumbnailTableRowStyle]}>
+    <div key={index} css={[backgroundBoxStyle(theme), thumbnailTableRowStyle(500)]}>
       <div css={thumbnailTableRowTitleStyle}>
         {t("thumbnailSimple.rowTitle")}
       </div>
@@ -582,9 +590,11 @@ const ThumbnailButtonsSimple : React.FC<{
 /**
  * CSS shared between multi and simple display mode
  */
-const thumbnailTableRowStyle = css({
+const thumbnailTableRowStyle = (maxWidth: number) => css({
   display: 'flex',
   flexDirection: 'column',
+  width: '100%',
+  maxWidth: `${maxWidth}px`,
 })
 
 const thumbnailTableRowTitleStyle = css({

--- a/src/main/Thumbnail.tsx
+++ b/src/main/Thumbnail.tsx
@@ -91,6 +91,7 @@ const Thumbnail : React.FC = () => {
 
   const bottomStyle = css({
     display: 'flex',
+    width: '100%',
     flexDirection: 'column',
     alignItems: 'center',
   })

--- a/src/main/VideoPlayers.tsx
+++ b/src/main/VideoPlayers.tsx
@@ -325,6 +325,9 @@ export const VideoPlayer = React.forwardRef(
           canvasContext.drawImage(video, 0, 0);
           return canvas.toDataURL('image/png')
         }
+      },
+      getWidth() {
+        return (ref.current?.getInternalPlayer() as HTMLVideoElement).clientWidth
       }
     }));
 

--- a/src/main/VideoPlayers.tsx
+++ b/src/main/VideoPlayers.tsx
@@ -24,7 +24,7 @@ import { useTheme } from "../themes";
 
 import { backgroundBoxStyle, flexGapReplacementStyle } from '../cssStyles'
 
-const VideoPlayers: React.FC<{refs: any, widthInPercent?: number}> = ({refs, widthInPercent = 100}) => {
+const VideoPlayers: React.FC<{refs: any, widthInPercent?: number, maxHeightInPixel?: number}> = ({refs, widthInPercent = 100, maxHeightInPixel = 300}) => {
 
   const videoURLs = useSelector(selectVideoURL)
   const videoCount = useSelector(selectVideoCount)
@@ -37,7 +37,7 @@ const VideoPlayers: React.FC<{refs: any, widthInPercent?: number}> = ({refs, wid
     borderRadius: '5px',
     ...(flexGapReplacementStyle(10, false)),
 
-    maxHeight: '300px',
+    maxHeight: maxHeightInPixel + 'px',
   });
 
   // Initialize video players


### PR DESCRIPTION
Currently in the thumbnail view, the videos are the same size as the thumbnails. However, the outlines surrounding them are different, as the outline around the thumbnails also contains buttons. This enlarges the videos to make the outlines have the same width.

Partially addresses #1207. From a usability point-of-view, I don't think making the timeline the same width as the stuff above it is currently reasonable. Since we cannot zoom into the timeline (yet™), it should be as wide as possible. 