### PR TITLE
Fix web console error message about xmlnsSvg

### DIFF
--- a/src/img/opencast-editor.svg
+++ b/src/img/opencast-editor.svg
@@ -10,7 +10,7 @@
    enable-background="new 0 0 717.17 540"
    xml:space="preserve"
    xmlns="http://www.w3.org/2000/svg"
-   xmlnsSvg="http://www.w3.org/2000/svg"><g
+   xmlnssvg="http://www.w3.org/2000/svg"><g
    id="g3"
    style="fill:#ffffff;fill-opacity:1"
    transform="matrix(1.1241114,0,0,1.1241114,-189.53592,-271.99556)"><g


### PR DESCRIPTION
Starting the editor will prompt an error message about spelling in our opencast-editor.svg. This complies with the solution suggested by the error message, also because I'm fairly certain that we do not care about this parameter at all.