### PR TITLE
Fix subtiles not saved for new subtitles 

### DIFF
--- a/src/main/SubtitleEditor.tsx
+++ b/src/main/SubtitleEditor.tsx
@@ -33,7 +33,7 @@ const SubtitleEditor: React.FC = () => {
   const [getError, setGetError] = useState<string | undefined>(undefined);
   const subtitle = useAppSelector(selectSelectedSubtitleById);
   const selectedId = useAppSelector(selectSelectedSubtitleId);
-  const captionTrack = useAppSelector(selectSubtitlesFromOpencastById(selectedId));
+  const captionTrack = useAppSelector(state => selectSubtitlesFromOpencastById(state, selectedId));
   const theme = useTheme();
 
   // Prepare subtitle in redux

--- a/src/main/WorkflowConfiguration.tsx
+++ b/src/main/WorkflowConfiguration.tsx
@@ -30,7 +30,10 @@ import {
   selectPostStatus,
   setHasChanges as metadataSetHasChanges,
 } from "../redux/metadataSlice";
-import { selectSubtitles } from "../redux/subtitleSlice";
+import {
+  selectSubtitles,
+  setHasChanges as subtitleSetHasChanges,
+} from "../redux/subtitleSlice";
 import { serializeSubtitle } from "../util/utilityFunctions";
 import { useTheme } from "../themes";
 
@@ -105,6 +108,7 @@ export const SaveAndProcessButton: React.FC<{ text: string; }> = ({ text }) => {
       dispatch(setEnd({ hasEnded: true, value: "success" }));
       dispatch(videoSetHasChanges(false));
       dispatch(metadataSetHasChanges(false));
+      dispatch(subtitleSetHasChanges(false));
     }
   }, [dispatch, metadataStatus, workflowStatus]);
 

--- a/src/redux/subtitleSlice.ts
+++ b/src/redux/subtitleSlice.ts
@@ -81,7 +81,7 @@ export const subtitleSlice = createSlice({
     setCueAtIndex: (state, action: PayloadAction<{ identifier: string, cueIndex: number, newCue: SubtitleCue; }>) => {
       if (action.payload.cueIndex < 0 ||
         action.payload.cueIndex >= state.subtitles[action.payload.identifier].cues.length) {
-        console.log("WARNING: Tried to set segment for subtitle " + action.payload.identifier +
+        console.warn("Tried to set segment for subtitle " + action.payload.identifier +
           " but was out of range");
         return;
       }
@@ -93,6 +93,9 @@ export const subtitleSlice = createSlice({
       cue.startTime = Math.round(action.payload.newCue.startTime);
       cue.endTime = Math.round(action.payload.newCue.endTime);
 
+      if (cue.tree.children.length <= 0) {
+        cue.tree.children[0] = { type: "text", value: action.payload.newCue.text };
+      }
       cue.tree.children[0].value = action.payload.newCue.text;
 
       state.subtitles[action.payload.identifier].cues[action.payload.cueIndex] = cue;


### PR DESCRIPTION
Creating a new subtitle from scratch was broken, because the text in the cues was not saved to Opencast.
This fixes that.

Includes #1266. 

Should also fix #888.