### PR TITLE
Remove whitespace

### DIFF
--- a/src/main/SubtitleSelect.tsx
+++ b/src/main/SubtitleSelect.tsx
@@ -94,7 +94,7 @@ const SubtitleSelect: React.FC = () => {
   // Converts tags from the config file format to opencast format
   const convertTags = (tags: subtitleTags) => {
     return Object.entries(tags)
-      .map(tag => `${tag[0]}: ${tag[1]}`)
+      .map(tag => `${tag[0]}:${tag[1]}`)
       .concat();
   };
 


### PR DESCRIPTION
The language tag contains a space between the colon and the language part. This commit removes the space so the tag looks like `lang:de` instead of `lang: de`.