### PR TITLE
Set vite base

### DIFF
--- a/.github/mock/editor/ID-dual-stream-demo/metadata.json
+++ b/.github/mock/editor/ID-dual-stream-demo/metadata.json
@@ -1,1 +1,217 @@
-[{"flavor":"dublincore\/episode","title":"EVENTS.EVENTS.DETAILS.CATALOG.EPISODE","fields":[{"readOnly":false,"id":"title","label":"EVENTS.EVENTS.DETAILS.METADATA.TITLE","type":"text","value":"Dual-Stream Demo","required":true},{"readOnly":false,"id":"subject","label":"EVENTS.EVENTS.DETAILS.METADATA.SUBJECT","type":"text","value":"","required":false},{"readOnly":false,"id":"description","label":"EVENTS.EVENTS.DETAILS.METADATA.DESCRIPTION","type":"text_long","value":"","required":false},{"translatable":true,"readOnly":false,"id":"language","label":"EVENTS.EVENTS.DETAILS.METADATA.LANGUAGE","collection":{"LANGUAGES.SLOVENIAN":"slv","LANGUAGES.PORTUGUESE":"por","LANGUAGES.ROMANSH":"roh","LANGUAGES.ARABIC":"ara","LANGUAGES.POLISH":"pol","LANGUAGES.ITALIAN":"ita","LANGUAGES.CHINESE":"zho","LANGUAGES.FINNISH":"fin","LANGUAGES.DANISH":"dan","LANGUAGES.UKRAINIAN":"ukr","LANGUAGES.FRENCH":"fra","LANGUAGES.SPANISH":"spa","LANGUAGES.GERMAN_CH":"gsw","LANGUAGES.NORWEGIAN":"nor","LANGUAGES.RUSSIAN":"rus","LANGUAGES.JAPANESE":"jpx","LANGUAGES.DUTCH":"nld","LANGUAGES.TURKISH":"tur","LANGUAGES.HINDI":"hin","LANGUAGES.SWEDISH":"swa","LANGUAGES.ENGLISH":"eng","LANGUAGES.GERMAN":"deu"},"type":"text","value":"","required":false},{"readOnly":false,"id":"rightsHolder","label":"EVENTS.EVENTS.DETAILS.METADATA.RIGHTS","type":"text","value":"","required":false},{"translatable":true,"readOnly":false,"id":"license","label":"EVENTS.EVENTS.DETAILS.METADATA.LICENSE","collection":{"{\"label\":\"EVENTS.LICENSE.CC0\", \"order\":8, \"selectable\": true}":"CC0","{\"label\":\"EVENTS.LICENSE.CCBYND\", \"order\":4, \"selectable\": true}":"CC-BY-ND","{\"label\":\"EVENTS.LICENSE.CCBYNCND\", \"order\":7, \"selectable\": true}":"CC-BY-NC-ND","{\"label\":\"EVENTS.LICENSE.CCBYNCSA\", \"order\":6, \"selectable\": true}":"CC-BY-NC-SA","{\"label\":\"EVENTS.LICENSE.ALLRIGHTS\", \"order\":1, \"selectable\": true}":"ALLRIGHTS","{\"label\":\"EVENTS.LICENSE.CCBYSA\", \"order\":3, \"selectable\": true}":"CC-BY-SA","{\"label\":\"EVENTS.LICENSE.CCBYNC\", \"order\":5, \"selectable\": true}":"CC-BY-NC","{\"label\":\"EVENTS.LICENSE.CCBY\", \"order\":2, \"selectable\": true}":"CC-BY"},"type":"ordered_text","value":"CC-BY-SA","required":false},{"translatable":false,"readOnly":false,"id":"isPartOf","label":"EVENTS.EVENTS.DETAILS.METADATA.SERIES","collection":{"Wiki Commons Content":"ID-wiki-commons","AV-Portal Content":"ID-av-portal","Open Media for Opencast":"ID-openmedia-opencast","Blender Foundation Productions":"ID-blender-foundation"},"type":"text","value":"","required":false},{"translatable":false,"readOnly":false,"id":"creator","label":"EVENTS.EVENTS.DETAILS.METADATA.PRESENTERS","collection":{"NASA Johnson":"NASA Johnson","NASA":"NASA","Rosatrieu":"Rosatrieu","I. Elgamal":"I. Elgamal","TIB AV-Portal Hannover":"TIB AV-Portal Hannover","Wiki Commons":"Wiki Commons","Lars Kiesow":"Lars Kiesow","Andy Goralczyk":"Andy Goralczyk","Olaf Schulte":"Olaf Schulte","Administrator":"Administrator","Nature Stock Videos":"Nature Stock Videos","Capture Agent":"Capture Agent","Blender Foundation":"Blender Foundation","Pixabay":"Pixabay","System User":"System User"},"type":"mixed_text","value":["Lars Kiesow"],"required":false},{"translatable":false,"readOnly":false,"id":"contributor","label":"EVENTS.EVENTS.DETAILS.METADATA.CONTRIBUTORS","collection":{"NASA Johnson":"NASA Johnson","NASA":"NASA","Rosatrieu":"Rosatrieu","I. Elgamal":"I. Elgamal","TIB AV-Portal Hannover":"TIB AV-Portal Hannover","Wiki Commons":"Wiki Commons","Lars Kiesow":"Lars Kiesow","Andy Goralczyk":"Andy Goralczyk","Olaf Schulte":"Olaf Schulte","Administrator":"Administrator","Nature Stock Videos":"Nature Stock Videos","Capture Agent":"Capture Agent","Blender Foundation":"Blender Foundation","Pixabay":"Pixabay","System User":"System User"},"type":"mixed_text","value":[],"required":false},{"readOnly":false,"id":"startDate","label":"EVENTS.EVENTS.DETAILS.METADATA.START_DATE","type":"date","value":"2022-02-03T01:02:00.000Z","required":false},{"readOnly":false,"id":"duration","label":"EVENTS.EVENTS.DETAILS.METADATA.DURATION","type":"text","value":"00:00:00","required":false},{"readOnly":false,"id":"location","label":"EVENTS.EVENTS.DETAILS.METADATA.LOCATION","type":"text","value":"","required":false},{"readOnly":false,"id":"source","label":"EVENTS.EVENTS.DETAILS.METADATA.SOURCE","type":"text","value":"","required":false},{"readOnly":true,"id":"created","label":"EVENTS.EVENTS.DETAILS.METADATA.CREATED","type":"date","value":"2022-02-03T01:02:00.000Z","required":false},{"readOnly":true,"id":"publisher","label":"EVENTS.EVENTS.DETAILS.METADATA.PUBLISHER","type":"text","value":"","required":false},{"readOnly":true,"id":"identifier","label":"EVENTS.EVENTS.DETAILS.METADATA.ID","type":"text","value":"ID-dual-stream-demo","required":false}]}]
+[
+    {
+        "flavor": "dublincore\/episode",
+        "title": "EVENTS.EVENTS.DETAILS.CATALOG.EPISODE",
+        "fields": [
+            {
+                "readOnly": false,
+                "id": "title",
+                "label": "EVENTS.EVENTS.DETAILS.METADATA.TITLE",
+                "type": "text",
+                "value": "Dual-Stream Demo",
+                "required": true
+            },
+            {
+                "readOnly": false,
+                "id": "subject",
+                "label": "EVENTS.EVENTS.DETAILS.METADATA.SUBJECT",
+                "type": "text",
+                "value": "",
+                "required": false
+            },
+            {
+                "readOnly": false,
+                "id": "description",
+                "label": "EVENTS.EVENTS.DETAILS.METADATA.DESCRIPTION",
+                "type": "text_long",
+                "value": "",
+                "required": false
+            },
+            {
+                "translatable": true,
+                "readOnly": false,
+                "id": "language",
+                "label": "EVENTS.EVENTS.DETAILS.METADATA.LANGUAGE",
+                "collection": {
+                    "LANGUAGES.SLOVENIAN": "slv",
+                    "LANGUAGES.PORTUGUESE": "por",
+                    "LANGUAGES.ROMANSH": "roh",
+                    "LANGUAGES.ARABIC": "ara",
+                    "LANGUAGES.POLISH": "pol",
+                    "LANGUAGES.ITALIAN": "ita",
+                    "LANGUAGES.CHINESE": "zho",
+                    "LANGUAGES.FINNISH": "fin",
+                    "LANGUAGES.DANISH": "dan",
+                    "LANGUAGES.UKRAINIAN": "ukr",
+                    "LANGUAGES.FRENCH": "fra",
+                    "LANGUAGES.SPANISH": "spa",
+                    "LANGUAGES.GERMAN_CH": "gsw",
+                    "LANGUAGES.NORWEGIAN": "nor",
+                    "LANGUAGES.RUSSIAN": "rus",
+                    "LANGUAGES.JAPANESE": "jpx",
+                    "LANGUAGES.DUTCH": "nld",
+                    "LANGUAGES.TURKISH": "tur",
+                    "LANGUAGES.HINDI": "hin",
+                    "LANGUAGES.SWEDISH": "swa",
+                    "LANGUAGES.ENGLISH": "eng",
+                    "LANGUAGES.GERMAN": "deu"
+                },
+                "type": "text",
+                "value": "",
+                "required": false
+            },
+            {
+                "readOnly": false,
+                "id": "rightsHolder",
+                "label": "EVENTS.EVENTS.DETAILS.METADATA.RIGHTS",
+                "type": "text",
+                "value": "",
+                "required": false
+            },
+            {
+                "translatable": true,
+                "readOnly": false,
+                "id": "license",
+                "label": "EVENTS.EVENTS.DETAILS.METADATA.LICENSE",
+                "collection": {
+                    "{\"label\":\"EVENTS.LICENSE.CC0\", \"order\":8, \"selectable\": true}": "CC0",
+                    "{\"label\":\"EVENTS.LICENSE.CCBYND\", \"order\":4, \"selectable\": true}": "CC-BY-ND",
+                    "{\"label\":\"EVENTS.LICENSE.CCBYNCND\", \"order\":7, \"selectable\": true}": "CC-BY-NC-ND",
+                    "{\"label\":\"EVENTS.LICENSE.CCBYNCSA\", \"order\":6, \"selectable\": true}": "CC-BY-NC-SA",
+                    "{\"label\":\"EVENTS.LICENSE.ALLRIGHTS\", \"order\":1, \"selectable\": true}": "ALLRIGHTS",
+                    "{\"label\":\"EVENTS.LICENSE.CCBYSA\", \"order\":3, \"selectable\": true}": "CC-BY-SA",
+                    "{\"label\":\"EVENTS.LICENSE.CCBYNC\", \"order\":5, \"selectable\": true}": "CC-BY-NC",
+                    "{\"label\":\"EVENTS.LICENSE.CCBY\", \"order\":2, \"selectable\": true}": "CC-BY"
+                },
+                "type": "ordered_text",
+                "value": "CC-BY-SA",
+                "required": false
+            },
+            {
+                "translatable": false,
+                "readOnly": false,
+                "id": "isPartOf",
+                "label": "EVENTS.EVENTS.DETAILS.METADATA.SERIES",
+                "collection": {
+                    "Wiki Commons Content": "ID-wiki-commons",
+                    "AV-Portal Content": "ID-av-portal",
+                    "Open Media for Opencast": "ID-openmedia-opencast",
+                    "Blender Foundation Productions": "ID-blender-foundation"
+                },
+                "type": "text",
+                "value": "",
+                "required": false
+            },
+            {
+                "translatable": false,
+                "readOnly": false,
+                "id": "creator",
+                "label": "EVENTS.EVENTS.DETAILS.METADATA.PRESENTERS",
+                "collection": {
+                    "NASA Johnson": "NASA Johnson",
+                    "NASA": "NASA",
+                    "Rosatrieu": "Rosatrieu",
+                    "I. Elgamal": "I. Elgamal",
+                    "TIB AV-Portal Hannover": "TIB AV-Portal Hannover",
+                    "Wiki Commons": "Wiki Commons",
+                    "Lars Kiesow": "Lars Kiesow",
+                    "Andy Goralczyk": "Andy Goralczyk",
+                    "Olaf Schulte": "Olaf Schulte",
+                    "Administrator": "Administrator",
+                    "Nature Stock Videos": "Nature Stock Videos",
+                    "Capture Agent": "Capture Agent",
+                    "Blender Foundation": "Blender Foundation",
+                    "Pixabay": "Pixabay",
+                    "System User": "System User"
+                },
+                "type": "mixed_text",
+                "value": [
+                    "Lars Kiesow"
+                ],
+                "required": false
+            },
+            {
+                "translatable": false,
+                "readOnly": false,
+                "id": "contributor",
+                "label": "EVENTS.EVENTS.DETAILS.METADATA.CONTRIBUTORS",
+                "collection": {
+                    "NASA Johnson": "NASA Johnson",
+                    "NASA": "NASA",
+                    "Rosatrieu": "Rosatrieu",
+                    "I. Elgamal": "I. Elgamal",
+                    "TIB AV-Portal Hannover": "TIB AV-Portal Hannover",
+                    "Wiki Commons": "Wiki Commons",
+                    "Lars Kiesow": "Lars Kiesow",
+                    "Andy Goralczyk": "Andy Goralczyk",
+                    "Olaf Schulte": "Olaf Schulte",
+                    "Administrator": "Administrator",
+                    "Nature Stock Videos": "Nature Stock Videos",
+                    "Capture Agent": "Capture Agent",
+                    "Blender Foundation": "Blender Foundation",
+                    "Pixabay": "Pixabay",
+                    "System User": "System User"
+                },
+                "type": "mixed_text",
+                "value": [],
+                "required": false
+            },
+            {
+                "readOnly": false,
+                "id": "startDate",
+                "label": "EVENTS.EVENTS.DETAILS.METADATA.START_DATE",
+                "type": "date",
+                "value": "2022-02-03T01:02:00.000Z",
+                "required": false
+            },
+            {
+                "readOnly": false,
+                "id": "duration",
+                "label": "EVENTS.EVENTS.DETAILS.METADATA.DURATION",
+                "type": "text",
+                "value": "00:01:04",
+                "required": false
+            },
+            {
+                "readOnly": false,
+                "id": "location",
+                "label": "EVENTS.EVENTS.DETAILS.METADATA.LOCATION",
+                "type": "text",
+                "value": "",
+                "required": false
+            },
+            {
+                "readOnly": false,
+                "id": "source",
+                "label": "EVENTS.EVENTS.DETAILS.METADATA.SOURCE",
+                "type": "text",
+                "value": "",
+                "required": false
+            },
+            {
+                "readOnly": true,
+                "id": "created",
+                "label": "EVENTS.EVENTS.DETAILS.METADATA.CREATED",
+                "type": "date",
+                "value": "2022-02-03T01:02:00.000Z",
+                "required": false
+            },
+            {
+                "readOnly": true,
+                "id": "publisher",
+                "label": "EVENTS.EVENTS.DETAILS.METADATA.PUBLISHER",
+                "type": "text",
+                "value": "",
+                "required": false
+            },
+            {
+                "readOnly": true,
+                "id": "identifier",
+                "label": "EVENTS.EVENTS.DETAILS.METADATA.ID",
+                "type": "text",
+                "value": "ID-dual-stream-demo",
+                "required": false
+            }
+        ]
+    }
+]

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # testing
 /coverage
+/playwright-report
 
 # production
 /build

--- a/src/config.ts
+++ b/src/config.ts
@@ -180,7 +180,7 @@ export const init = async () => {
 const loadContextSettings = async () => {
 
   // Try to retrieve the context settings.
-  let basepath = import.meta.env.PUBLIC_URL || "/";
+  let basepath = import.meta.env.BASE_URL || "/";
   if (!basepath.endsWith("/")) {
     basepath += "/";
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -190,7 +190,7 @@ const loadContextSettings = async () => {
   // server root.
   const settingsPath = import.meta.env.VITE_APP_SETTINGS_PATH || CONTEXT_SETTINGS_FILE;
   const base = settingsPath.startsWith("/") ? "" : basepath;
-  const url = `${window.location.origin}${base}${settingsPath}`;
+  const url = new URL(base.concat(settingsPath), window.location.origin);
   let response;
   try {
     response = await fetch(url);

--- a/src/i18n/config.tsx
+++ b/src/i18n/config.tsx
@@ -2,7 +2,7 @@ import i18next, { InitOptions } from "i18next";
 import { initReactI18next } from "react-i18next";
 import LanguageDetector from "i18next-browser-languagedetector";
 
-import locales from "./locales/locales.json";
+import locales from "./locales.json";
 
 const debug = Boolean(new URLSearchParams(window.location.search).get("debug"));
 

--- a/src/i18n/locales.json
+++ b/src/i18n/locales.json
@@ -1,0 +1,9 @@
+[
+    "de-DE.json",
+    "en-US.json",
+    "es-ES.json",
+    "fr-FR.json",
+    "nl-NL.json",
+    "zh-CN.json",
+    "zh-TW.json"
+]

--- a/src/i18n/locales/locales.json
+++ b/src/i18n/locales/locales.json
@@ -1,1 +1,0 @@
-[ "de-DE.json", "en-US.json", "es-ES.json", "fr-FR.json", "nl-NL.json", "zh-CN.json", "zh-TW.json" ]

--- a/tests/metadata.test.ts
+++ b/tests/metadata.test.ts
@@ -71,7 +71,7 @@ test.describe('Test Metadata-Page', () => {
 });
 
 const input = ['title', 'subject', 'rightsHolder', 'duration', 'location', 'source'];
-const iValue = ['Dual-Stream Demo', '', '', '00:00:00', '', ''];
+const iValue = ['Dual-Stream Demo', '', '', '00:01:04', '', ''];
 const iFill = ['Test-Title', 'Test-Subject', 'Test-Rights', '00:02:45', 'Test-Location', 'Test-Source'];
 
 const dropdown = ['language', 'license', 'isPartOf', 'creator', 'contributor'];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ const commitHash = child.execSync("git rev-parse HEAD").toString().trim();
 // https://vitejs.dev/config/
 export default defineConfig(() => {
   return {
+    base: process.env.PUBLIC_URL || "",
     server: {
       open: true,
     },


### PR DESCRIPTION
Vite does not honor the PUBLIC_URL environment variable; we need to set the base via that variable to support building versions with a path different from the root.