### PR TITLE
Change wordings in finish menu

### DIFF
--- a/src/i18n/locales/de-DE.json
+++ b/src/i18n/locales/de-DE.json
@@ -49,7 +49,7 @@
     },
     "finishMenu": {
         "save-button": "Änderungen speichern",
-        "start-button": "Verarbeitung starten",
+        "start-button": "Änderungen speichern & veröffentlichen",
         "discard-button": "Änderungen verwerfen"
     },
     "save": {
@@ -77,10 +77,10 @@
         "info-text": "Änderungen erfolgreich in Opencast gespeichert. Die Bearbeitung Ihrer Änderungen kann einige Zeit dauern, bitte haben Sie etwas Geduld. Sie können nun den Editor schließen.\n"
     },
     "workflowSelection": {
-        "saveAndProcess-text": "Speichern & verarbeiten",
+        "saveAndProcess-text": "Speichern & veröffentlichen",
         "selectWF-text": "Workflow wählen",
         "noWorkflows-text": "Es gibt keine Workflows zum Verarbeiten Ihrer Änderungen. Bitte speichern Sie Ihre Änderungen und kontaktieren Sie einen Administrator.\n",
-        "oneWorkflow-text": "Das Video wird mit dem Workflow \"{{workflow}}\" geschnitten und verarbeitet. <3/> Dies wird einige Zeit dauern.\n",
+        "oneWorkflow-text": "Die Änderungen werden gespeichert und das Video wird mit dem Workflow \"{{workflow}}\" geschnitten und verarbeitet. <3/> Dies wird einige Zeit dauern.\n",
         "manyWorkflows-text": "Wählen Sie aus, welchen Workflow Opencast für die Verarbeitung verwenden soll.",
         "startProcessing-button": "Verarbeitung starten",
         "back-button": "Zurück",

--- a/src/i18n/locales/de-DE.json
+++ b/src/i18n/locales/de-DE.json
@@ -49,7 +49,7 @@
     },
     "finishMenu": {
         "save-button": "Änderungen speichern",
-        "start-button": "Änderungen speichern & veröffentlichen",
+        "start-button": "Änderungen speichern & verarbeiten",
         "discard-button": "Änderungen verwerfen"
     },
     "save": {
@@ -77,7 +77,7 @@
         "info-text": "Änderungen erfolgreich in Opencast gespeichert. Die Bearbeitung Ihrer Änderungen kann einige Zeit dauern, bitte haben Sie etwas Geduld. Sie können nun den Editor schließen.\n"
     },
     "workflowSelection": {
-        "saveAndProcess-text": "Speichern & veröffentlichen",
+        "saveAndProcess-text": "Speichern & verarbeiten",
         "selectWF-text": "Workflow wählen",
         "noWorkflows-text": "Es gibt keine Workflows zum Verarbeiten Ihrer Änderungen. Bitte speichern Sie Ihre Änderungen und kontaktieren Sie einen Administrator.\n",
         "oneWorkflow-text": "Die Änderungen werden gespeichert und das Video wird mit dem Workflow \"{{workflow}}\" geschnitten und verarbeitet. <3/> Dies wird einige Zeit dauern.\n",

--- a/src/i18n/locales/de-DE.json
+++ b/src/i18n/locales/de-DE.json
@@ -49,7 +49,7 @@
     },
     "finishMenu": {
         "save-button": "Änderungen speichern",
-        "start-button": "Änderungen speichern & verarbeiten",
+        "start-button": "Verarbeitung starten",
         "discard-button": "Änderungen verwerfen"
     },
     "save": {
@@ -80,7 +80,7 @@
         "saveAndProcess-text": "Speichern & verarbeiten",
         "selectWF-text": "Workflow wählen",
         "noWorkflows-text": "Es gibt keine Workflows zum Verarbeiten Ihrer Änderungen. Bitte speichern Sie Ihre Änderungen und kontaktieren Sie einen Administrator.\n",
-        "oneWorkflow-text": "Die Änderungen werden gespeichert und das Video wird mit dem Workflow \"{{workflow}}\" geschnitten und verarbeitet. <3/> Dies wird einige Zeit dauern.\n",
+        "oneWorkflow-text": "Das Video wird mit dem Workflow \"{{workflow}}\" geschnitten und verarbeitet. <3/> Dies wird einige Zeit dauern.\n",
         "manyWorkflows-text": "Wählen Sie aus, welchen Workflow Opencast für die Verarbeitung verwenden soll.",
         "startProcessing-button": "Verarbeitung starten",
         "back-button": "Zurück",

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -52,7 +52,7 @@
 
     "finishMenu": {
       "save-button": "Save changes",
-      "start-button": "Save and publish changes",
+      "start-button": "Save and process changes",
       "discard-button": "Discard changes"
     },
 
@@ -84,7 +84,7 @@
     },
 
     "workflowSelection": {
-      "saveAndProcess-text": "Save and Publish",
+      "saveAndProcess-text": "Save and Process",
       "selectWF-text": "Select a workflow",
       "noWorkflows-text": "There are no workflows to process your changes with. Please save your changes and contact an administrator.\n",
       "oneWorkflow-text": "The changes will be saved and the video will be cut and processed with the workflow \"{{workflow}}\". <3/> This will take some time.\n",

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -52,7 +52,7 @@
 
     "finishMenu": {
       "save-button": "Save changes",
-      "start-button": "Start processing",
+      "start-button": "Save and publish changes",
       "discard-button": "Discard changes"
     },
 
@@ -84,10 +84,10 @@
     },
 
     "workflowSelection": {
-      "saveAndProcess-text": "Save and Process",
+      "saveAndProcess-text": "Save and Publish",
       "selectWF-text": "Select a workflow",
       "noWorkflows-text": "There are no workflows to process your changes with. Please save your changes and contact an administrator.\n",
-      "oneWorkflow-text": "The video will be cut and processed with the workflow \"{{workflow}}\". <3/> This will take some time.\n",
+      "oneWorkflow-text": "The changes will be saved and the video will be cut and processed with the workflow \"{{workflow}}\". <3/> This will take some time.\n",
       "manyWorkflows-text": "Select which workflow Opencast should use for processing.",
       "startProcessing-button": "Start processing",
       "back-button": "Take me back",

--- a/src/main/WorkflowSelection.tsx
+++ b/src/main/WorkflowSelection.tsx
@@ -135,7 +135,8 @@ const WorkflowSelection: React.FC = () => {
         render(
           t("workflowSelection.saveAndProcess-text"),
           <Trans i18nKey="workflowSelection.oneWorkflow-text">
-            The video will be cut and processed with the workflow {{ workflow: workflows[0].name }}.<br />
+            The changes will be saved and the video will be cut and processed with
+            the workflow {{ workflow: workflows[0].name }}.<br />
             This will take some time.
           </Trans>,
           false,


### PR DESCRIPTION
Change the the wording of the "Start processing" button to "Save and publish changes" to better differentiate the buttons. Additionally, this should highlight that videos can be published with this button.

I haven't changed the existing translations, as I don't know what to do with them.

Related #1131