### PR TITLE
Subtitle editor: Allow to change end time of segment in timeline by drag and drop

### DIFF
--- a/src/main/SubtitleTimeline.tsx
+++ b/src/main/SubtitleTimeline.tsx
@@ -287,24 +287,13 @@ const TimelineSubtitleSegment: React.FC<{
   const onResizeAbsolute: ResizableProps["onResize"] = (_event, { size, handle }) => {
     // Possible TODO: Find a way to stop resizing a segment beyond 0ms here instead of later
     let newLeft = absoluteLeft;
-    let newTop = absoluteTop;
-    const deltaHeight = size.height - absoluteHeight;
-    const deltaWidth = size.width - absoluteWidth;
-    if (handle[0] === "n") {
-      newTop -= deltaHeight;
-    } else if (handle[0] === "s") {
-      newTop += deltaHeight;
-    }
+
     if (handle[handle.length - 1] === "w") {
-      newLeft -= deltaWidth;
-    } else if (handle[handle.length - 1] === "e") {
-      newLeft += deltaWidth;
+      newLeft -= size.width - absoluteWidth;
     }
 
     setAbsoluteWidth(size.width);
-    setAbsoluteHeight(size.height);
     setAbsoluteLeft(newLeft);
-    setAbsoluteTop(newTop);
   };
 
   // Update redux state based on the resize
@@ -323,7 +312,7 @@ const TimelineSubtitleSegment: React.FC<{
     }
     // if handle === right, update endTime
     if (handle === "e") {
-      newEndTime = props.cue.endTime + timeDiff;
+      newEndTime = props.cue.endTime - timeDiff;
     }
 
     dispatchNewTimes(newStartTime, newEndTime);
@@ -407,11 +396,7 @@ const TimelineSubtitleSegment: React.FC<{
         width={absoluteWidth}
         onResize={onResizeAbsolute}
         onResizeStop={onResizeStop}
-        // TODO: The "e" handle is currently NOT WORKING CORRECTLY!
-        //  The errounous behaviour can already be seens with a minimal
-        //  draggable + resizable example.
-        //  Fix most likely requires changes in one of those modules
-        resizeHandles={["w"]}
+        resizeHandles={["w", "e"]}
       >
         <div css={segmentStyle} ref={nodeRef} onClick={onClick} id="no-scrolling">
           <span css={textStyle}>{props.cue.text}</span>


### PR DESCRIPTION
In the subtitle editor timeline, it was only possible to change the start time of a segment by drag and drop. This change makes it possible to change the end time in the same way.

Resolves #1314 