### PR TITLE
Dynamic skip threshold

### DIFF
--- a/src/redux/videoSlice.ts
+++ b/src/redux/videoSlice.ts
@@ -150,14 +150,18 @@ const videoSlice = createSlice({
     jumpToPreviousSegment: state => {
       let previousSegmentIndex = state.activeSegmentIndex - 1;
 
-      // Jump to start of active segment if current time is in interval [start + 3s, end)
-      if (state.currentlyAt >= state.segments[state.activeSegmentIndex].start + 3000) {
+      // Calculate the threshold for “being on a cut mark”.
+      // It is based on the video length, but in between 0.5s and 3.0s.
+      const threshold = Math.max(Math.min(state.duration / 100, 3000), 500);
+
+      // Jump to start of active segment if current time is in interval [start + threshold, end)
+      if (state.currentlyAt >= state.segments[state.activeSegmentIndex].start + threshold) {
         previousSegmentIndex = state.activeSegmentIndex;
       }
 
+      // Jump to start of first segment if we are anywhere in the first segment
       if (state.activeSegmentIndex == 0) {
-        // Jump to start of first segment
-        previousSegmentIndex = state.activeSegmentIndex;
+        previousSegmentIndex = 0;
       }
 
       updateCurrentlyAt(state, state.segments[previousSegmentIndex].start);


### PR DESCRIPTION
The hard-coded threshold of 3s for skipping to the previous segment instead of skipping to the start of the segment can be too long for short videos, where visually, you are far away from the actual cut mark.

![Screenshot from 2024-05-06 19-03-42](https://github.com/opencast/opencast-editor/assets/1008395/313a7240-b46a-4632-88fc-432b9c3ba94f)

This patch fixes the problem by making this a dynamic threshold based on the video duration with a minimum of 0.5s (guarding against a non-set video duration) and a maximum of 3s.