### PR TITLE
Fix releaste note configuration

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -13,6 +13,7 @@ changelog:
     - title: New Features
       labels:
         - type:feature
+        - type:enhancement
 
     - title: Usability and Accessibility
       labels:
@@ -30,4 +31,4 @@ changelog:
 
     - title: Other Changes
       labels:
-        - "type:*"
+        - "*"


### PR DESCRIPTION
This patch fixes the label configuration for release notes. Most notably, other patches was never picked up since only `*` is a special value.