### PR TITLE
Link subtitle tag documentation

### DIFF
--- a/editor-settings.toml
+++ b/editor-settings.toml
@@ -101,7 +101,8 @@
 [subtitles.languages]
 ## A list of languages for which new subtitles can be created
 # For each language, various tags can be specified
-# A list of officially recommended tags can be found at: TODO: link to opencast documentation for subtitle tags
+# A list of officially recommended tags can be found at
+# https://docs.opencast.org/develop/admin/#configuration/subtitles/#tags
 # At least the "lang" tag MUST be specified
 german = { lang = "de-DE" }
 english = { lang = "en-US", type = "closed-caption" }


### PR DESCRIPTION
This patch replaces the todo mark for linking the subtitle tags documentation with the actual link to that documentation.