### PR TITLE
Document and link translation rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Translating the Editor
 -------------
 You can help translating the editor to your language on [crowdin.com/project/opencast-editor](https://crowdin.com/project/opencast-editor). Simply request to join the project on Crowdin and start translating. If you are interested in translating a language which is not a target language right now, please create [a GitHub issue](https://github.com/opencast/opencast-editor/issues) and we will add the language.
 
+This project follows the general form of [Opencast's Localization Process](https://docs.opencast.org/develop/developer/#participate/localization/), especially regarding what happens when you need to [change an existing translation key](https://docs.opencast.org/develop/developer/#participate/localization/#i-need-to-update-the-wording-of-the-source-translation-what-happens).  Any questions not answered there should be referred to the mailing lists!
 
 Notes on Waveform Generation
 ----------------------------


### PR DESCRIPTION
opencast/opencast#5769 will soon add a section to the upstream translation docs regarding how to edit keys so let's link that here as well.
