### PR TITLE
Specify version of comment action

### DIFF
--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -92,9 +92,8 @@ jobs:
         git push origin gh-pages
 
     - name: Add comment with deployment location
-      uses: thollander/actions-comment-pull-request@main
+      uses: thollander/actions-comment-pull-request@v2
       with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         message: >
           This pull request is deployed at
           [test.editor.opencast.org/${{ steps.build-path.outputs.build }}


### PR DESCRIPTION
Instead of just specifying the main branch, this pull request specifies the latest major version of thollander/actions-comment-pull-request to use in GitHub Actions. We don't know how this action changes and tracking the default branch may cause this to break at any time. We can always update using Dependabot.