### PR TITLE
Sort Metadata dropdowns alphabetically

### DIFF
--- a/src/main/Metadata.tsx
+++ b/src/main/Metadata.tsx
@@ -476,15 +476,8 @@ const Metadata: React.FC = () => {
     if (field.collection) {
       // For whatever reason react-select uses "value" as their key, which is not at all confusing
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const library: [{ value: any, label: string, submitValue: any; }] =
-        [{ value: "", label: "No value", submitValue: "" }];
+      const library: { value: any, label: string, submitValue: any; }[] = [];
       Object.entries(field.collection).forEach(([key, value]) => {
-        // // Parse License
-        // let [err, result] = safeJsonParse(key)
-        // if (!err) {
-        //   console.log(result)
-        // }
-
         // Parse Label
         let descLabel = null;
         if (i18n.exists(`metadata.${field.id}`)) {
@@ -507,6 +500,8 @@ const Metadata: React.FC = () => {
           submitValue: value,
         });
       });
+      library.sort((a, b) => a.label.localeCompare(b.label));
+      library.unshift({ value: "", label: "No value", submitValue: "" });
       return library;
     } else {
       return null;


### PR DESCRIPTION
Adds simple sorting to the contents of dropdowns in the Metadata view. Sorts content alphabetically.

Resolves #1281