### PR TITLE
Fix initial appearance of thumbnail view

### DIFF
--- a/src/main/Thumbnail.tsx
+++ b/src/main/Thumbnail.tsx
@@ -252,7 +252,7 @@ const ThumbnailTableRow: React.FC<{
     // The "+40" comes from padding that is not included in the "getWidth" function
     generateRef.getWidth() + 40 :
     // Random default
-    440;
+    740;
 
   const renderPriority = (thumbnailPriority: number) => {
     if (isNaN(thumbnailPriority)) {
@@ -299,15 +299,17 @@ const ThumbnailDisplayer: React.FC<{ track: Track; }> = ({ track }) => {
 
   const generalStyle = css({
     width: "100%",
-    maxWidth: "457px",
+    maxWidth: "740px",
     aspectRatio: "16/9",
   });
 
   const imageStyle = css({
+    maxWidth: "457px",
   });
 
   const placeholderStyle = css({
     width: "100vw", // TODO: This is necessary to make the placeholder large enough, but prevents it from shrinking
+    maxWidth: "457px",
     backgroundColor: "grey",
     display: "flex",
     justifyContent: "center",


### PR DESCRIPTION
We want the boxes for the thumbnails and the videos to be roughly the same size, and display the buttons in the thumbnail boxes on the right if space allows. This was not happening when first clicking on the thumbnail view, wasting space and giving it a generally not so great look. This changes some max widths around to fix that.

Potentially a fix for #1282.

Before
![Bildschirmfoto vom 2024-05-30 09-42-10](https://github.com/opencast/opencast-editor/assets/14070005/c1bed727-f390-46cf-b961-a0c4171327a4)

After
![Bildschirmfoto vom 2024-05-30 09-42-47](https://github.com/opencast/opencast-editor/assets/14070005/9b4f53ce-009a-46bb-8098-e58ae596c619)
