### PR TITLE
Fix editor not playing audio due to video order

### DIFF
--- a/src/main/VideoPlayers.tsx
+++ b/src/main/VideoPlayers.tsx
@@ -21,6 +21,7 @@ import {
   setJumpTriggered,
   selectJumpTriggered,
   setCurrentlyAt,
+  selectVideos,
 } from "../redux/videoSlice";
 
 import ReactPlayer, { Config } from "react-player";
@@ -50,7 +51,9 @@ const VideoPlayers: React.FC<{
   maxHeightInPixel = 300,
 }) => {
 
-  const videoURLs = useAppSelector(selectVideoURL);
+  const videos = useAppSelector(selectVideos);
+  let primaryIndex = videos.findIndex(e => e.audio_stream.available === true);
+  primaryIndex = primaryIndex < 0 ? 0 : primaryIndex;
   const videoCount = useAppSelector(selectVideoCount);
 
   const videoPlayerAreaStyle = css({
@@ -71,8 +74,8 @@ const VideoPlayers: React.FC<{
       <VideoPlayer
         key={i}
         dataKey={i}
-        url={videoURLs[i]}
-        isPrimary={i === 0}
+        url={videos[i].uri}
+        isPrimary={i === primaryIndex}
         subtitleUrl={""}
         first={i === 0}
         last={i === videoCount - 1}


### PR DESCRIPTION
If the editor has multiple videos, it will consider one of them the "primary" video, from which it will play back audio. Even if that "primary" video does not have any audio.
This changes the logic so that the first video with audio the editor comes across is made the "primary" video, so that there should always be audio playing if audio is available.