### PR TITLE
Fix aspect ratio video box size in Safari

### DIFF
--- a/src/main/VideoPlayers.tsx
+++ b/src/main/VideoPlayers.tsx
@@ -413,7 +413,7 @@ export const VideoPlayer = React.forwardRef<VideoPlayerForwardRef, VideoPlayerPr
       // For multi videos, last from right side, sitting on start
       ...(last && !first) && { justifyContent: "start" },
 
-      // For multi videos, in between, occupy only the content!
+      // For multi videos, in between, fit content and center!
       ...(!first && !last) && { justifyContent: "center", flexBasis: "fit-content" },
     });
 

--- a/src/main/VideoPlayers.tsx
+++ b/src/main/VideoPlayers.tsx
@@ -403,9 +403,18 @@ export const VideoPlayer = React.forwardRef<VideoPlayerForwardRef, VideoPlayerPr
       height: "100%",
       width: "100%",
       display: "flex",
-      ...(first && first != last) && { justifyContent: "end" },
-      ...(last && first != last) && { justifyContent: "start" },
-      ...(first == last) && { justifyContent: "center" },
+
+      // For single video, center!
+      ...(first && last) && { justifyContent: "center" },
+
+      // For multi videos, first from right side, sitting on end
+      ...(first && !last) && { justifyContent: "end" },
+
+      // For multi videos, last from right side, sitting on start
+      ...(last && !first) && { justifyContent: "start" },
+
+      // For multi videos, in between, occupy only the content!
+      ...(!first && !last) && { justifyContent: "center", flexBasis: "fit-content" },
     });
 
     const render = () => {

--- a/src/main/VideoPlayers.tsx
+++ b/src/main/VideoPlayers.tsx
@@ -399,27 +399,38 @@ export const VideoPlayer = React.forwardRef<VideoPlayerForwardRef, VideoPlayerPr
       ...(last) && { borderBottomRightRadius: "5px" },
     });
 
+    const videoPlayerWrapperStyles = css({
+      height: "100%",
+      width: "100%",
+      display: "flex",
+      ...(first && first != last) && { justifyContent: "end" },
+      ...(last && first != last) && { justifyContent: "start" },
+      ...(first == last) && { justifyContent: "center" },
+    });
+
     const render = () => {
       if (!errorState) {
         return (
-          <ReactPlayer url={url}
-            css={[backgroundBoxStyle(theme), reactPlayerStyle]}
-            ref={ref}
-            width="unset"
-            height="unset"
-            playing={isPlaying}
-            volume={volume}
-            muted={!isPrimary || isMuted}
-            onProgress={onProgressCallback}
-            progressInterval={100}
-            onReady={onReadyCallback}
-            onPlay={onPlay}
-            onEnded={onEndedCallback}
-            onError={onErrorCallback}
-            tabIndex={-1}
-            config={playerConfig}
-            disablePictureInPicture
-          />
+          <div css={videoPlayerWrapperStyles}>
+            <ReactPlayer url={url}
+              css={[backgroundBoxStyle(theme), reactPlayerStyle]}
+              ref={ref}
+              width="unset"
+              height="100%"
+              playing={isPlaying}
+              volume={volume}
+              muted={!isPrimary || isMuted}
+              onProgress={onProgressCallback}
+              progressInterval={100}
+              onReady={onReadyCallback}
+              onPlay={onPlay}
+              onEnded={onEndedCallback}
+              onError={onErrorCallback}
+              tabIndex={-1}
+              config={playerConfig}
+              disablePictureInPicture
+            />
+          </div>
         );
       } else {
         return (


### PR DESCRIPTION
This PR fixes #1382 

### Problem
The problem is simply the lack of support in Safari that it could not recognize and allocate height based on aspect ratio.
The reason behind it, is because Safari support for aspect ratio was introduced in v15, and it is far behind the other browsers.

### Solution
In order to tackle that, this PR just introduces a wrapper around the React video player, by allowing it to have the height of 100% set for each video! That means now the height is not more a burden on browser to calculate based on aspect ratio!
The wrapper on the other hand is responsible to occupy the width and height designed for this section and let the video just take up the space it needs!

NOTE: it not only works for dual video, but the single video is covered too!

### To test
- you would need to have Safari to see the difference!
- patch this PR (locally, if you will)
- npm start (locally, if you will)
- Make sure you test it with single and dual videos in cutting page!