### PR TITLE
Remove a redundant workflow step

### DIFF
--- a/.github/workflows/playwright-test.yml
+++ b/.github/workflows/playwright-test.yml
@@ -25,9 +25,6 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
-    - name: Install Playwright
-      run: npm i -D @playwright/test
-
     - name: Install supported browsers
       run: npx playwright install
 


### PR DESCRIPTION
This project already depends on `@playwright/test`,
so there is no need to explicitly install it,
much less save it in `devDependencies`.
It should already come with the preceding run of `npm ci`.
