### PR TITLE
Center final message again

### DIFF
--- a/src/main/Body.tsx
+++ b/src/main/Body.tsx
@@ -28,10 +28,10 @@ const Body: React.FC = () => {
       );
     } else if (isEnd) {
       return (
-        <div>
+        <>
           <Lock />
           <TheEnd />
-        </div>
+        </>
       );
     } else if (isError) {
       return (


### PR DESCRIPTION
The message after successfully starting a workflow was stuck to the top of the page. This patch moves it to the center of the page again.