### PR TITLE
Remove CRA ts definition file

### DIFF
--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,2 +1,0 @@
-/* eslint-disable spaced-comment */
-/// <reference types="react-scripts" />


### PR DESCRIPTION
A file used by create-react-app. Since we switched to Vite, we don't need this anymore.