### PR TITLE
Fix the release script for macOS

### DIFF
--- a/.github/build-release.sh
+++ b/.github/build-release.sh
@@ -6,7 +6,7 @@ export PUBLIC_URL=/editor-ui
 export VITE_APP_SETTINGS_PATH="/ui/config/editor/editor-settings.toml"
 npm run build
 
-FILENAME="oc-editor-$(date --utc +%F).tar.gz"
+FILENAME="oc-editor-$(date -u +%F).tar.gz"
 cd build
 TMP="$(mktemp)"
 mv editor-settings.toml "$TMP"


### PR DESCRIPTION
`date --utc` is not POSIX and macOS doesn't have it. `-u` is the standard equivalent.

cf. opencast/opencast-admin-interface#326.