### PR TITLE
Properly center and space end screen

### DIFF
--- a/src/main/TheEnd.tsx
+++ b/src/main/TheEnd.tsx
@@ -34,7 +34,7 @@ const TheEnd: React.FC = () => {
 
   const theEndStyle = css({
     width: "100%",
-    height: "calc(100% - 64px)",
+    height: "calc(100vh - 64px)",
     display: "flex",
     flexDirection: "column",
     justifyContent: "center",


### PR DESCRIPTION
This patch fixes the issue that the text and the check mark icon of the end screen is pushed to the top of the end space with basically no spacing. This is caused by an incorrect CSS calculation.

---

Before:
![Screenshot from 2024-10-08 23-26-29](https://github.com/user-attachments/assets/39842698-5bf1-4b71-848d-35c223cf87f1)

After:
![Screenshot from 2024-10-08 23-26-14](https://github.com/user-attachments/assets/39e146d8-0dec-4b91-b9c5-a0e0d59e0b8e)
