### PR TITLE
Fix Crowdin integration

### DIFF
--- a/.github/workflows/crowdin-download-translations.yml
+++ b/.github/workflows/crowdin-download-translations.yml
@@ -1,4 +1,4 @@
-name: Update translations
+name: Crowdin » Download translations
 
 on:
   schedule:
@@ -28,13 +28,13 @@ jobs:
         run: |
           crowdin download --config .crowdin.yaml -b main
 
-      - name: add new translations
-        run: |
-          git add src/i18n/locales
-
       - name: update language list
         working-directory: src/i18n/locales
         run: $GITHUB_WORKSPACE/.github/generate-lngs.sh > ../lngs-generated.ts
+
+      - name: add new translations
+        run: |
+          git add src/i18n/
 
       - name: upload translations
         run: |

--- a/.github/workflows/crowdin-upload-keys.yml
+++ b/.github/workflows/crowdin-upload-keys.yml
@@ -1,4 +1,4 @@
-name: Deploy Crowdin keys
+name: Crowdin » Upload keys
 
 on:
   push:


### PR DESCRIPTION
This patch fixes the crowdin integration. The previous Actions workflow would generate the necessary patches gut never stage commit them to the repository.

This also renames the workflows so they have names identical to what we use in the admin interface.