### PR TITLE
Make behavior of forward button more intuitive

### DIFF
--- a/src/redux/videoSlice.ts
+++ b/src/redux/videoSlice.ts
@@ -171,14 +171,17 @@ const videoSlice = createSlice({
       state.jumpTriggered = true;
     },
     jumpToNextSegment: state => {
-      let nextSegmentIndex = state.activeSegmentIndex + 1;
+      const nextSegmentIndex = state.activeSegmentIndex + 1;
+      let jumpTarget = 0;
 
       if (state.activeSegmentIndex + 1 >= state.segments.length) {
-        // Jump to start of last segment
-        nextSegmentIndex = state.activeSegmentIndex;
+        // Jump to end of last segment
+        jumpTarget = state.segments[state.activeSegmentIndex].end;
+      } else {
+        jumpTarget = state.segments[nextSegmentIndex].start;
       }
 
-      updateCurrentlyAt(state, state.segments[nextSegmentIndex].start);
+      updateCurrentlyAt(state, jumpTarget);
       state.jumpTriggered = true;
     },
     addSegment: (state, action: PayloadAction<video["segments"][0]>) => {


### PR DESCRIPTION
This patch makes the forward button jump to the end of the video if you are currently in the last segment.

The previous behavior, jumping to the **beginning** of the last segment, made it so that the forward button sometimes made you go backwards in the video. This is especially confusing if there is only one segment, in which case the forward button put you at the beginning of the video.