### PR TITLE
Fix workflows not starting

### DIFF
--- a/src/main/Save.tsx
+++ b/src/main/Save.tsx
@@ -12,6 +12,7 @@ import { useAppDispatch, useAppSelector } from "../redux/store";
 import {
   selectHasChanges,
   selectSegments,
+  selectSelectedWorkflowId,
   selectTracks,
   setHasChanges as videoSetHasChanges,
 } from "../redux/videoSlice";
@@ -123,6 +124,7 @@ export const SaveButton: React.FC<{
   const tracks = useAppSelector(selectTracks);
   const subtitles = useAppSelector(selectSubtitles);
   const metadata = useAppSelector(selectCatalogs);
+  const selectedWorkflowId = useAppSelector(selectSelectedWorkflowId);
   const workflowStatus = useAppSelector(selectStatus);
   const theme = useTheme();
 
@@ -162,6 +164,7 @@ export const SaveButton: React.FC<{
       tracks: tracks,
       subtitles: prepareSubtitles(),
       metadata: metadata,
+      workflow: selectedWorkflowId ? [{ id: selectedWorkflowId }] : undefined,
     }));
   };
 


### PR DESCRIPTION
Fixes #1520.

We were not sending workflow ids anymore, so accordingly workflows were not started. This fixes that.

### How to test this
Make sure https://github.com/opencast/opencast/pull/6241/files is merged in the Opencast you test this with.
