### PR TITLE
Fix subtitle button height

### DIFF
--- a/src/main/SubtitleEditor.tsx
+++ b/src/main/SubtitleEditor.tsx
@@ -167,7 +167,7 @@ const SubtitleEditor: React.FC = () => {
 
 const subtitleButtonStyle = (theme: Theme) => css({
   fontSize: "16px",
-  height: "10px",
+  height: "42px",
   padding: "16px",
   justifyContent: "space-around",
   boxShadow: `${theme.boxShadow}`,
@@ -188,13 +188,13 @@ const DeleteButton: React.FC = () => {
   return (
     <>
       <ThemedTooltip title={t("subtitles.deleteButton-tooltip")}>
-        <div css={[basicButtonStyle(theme), subtitleButtonStyle(theme)]}
-          role="button"
+        <ProtoButton
           onClick={() => modalRef.current?.open()}
+          css={[basicButtonStyle(theme), subtitleButtonStyle(theme)]}
         >
           <LuTrash2 css={{ fontSize: "16px" }}/>
           <span>{t("subtitles.deleteButton-title")}</span>
-        </div>
+        </ProtoButton>
       </ThemedTooltip>
       {/* Hidden input field for upload */}
       <ConfirmationModal


### PR DESCRIPTION
Fixes https://github.com/opencast/opencast-editor/issues/1523.

Some button at the top of the subtitle editor were not the right height. This patch should fix that.

![Bildschirmfoto vom 2024-12-19 11-30-43](https://github.com/user-attachments/assets/beb628b2-fb0d-48e6-9b2a-7de8e3e7990d)


### How to test this

No special dependencies, can be tested as is. Install and look at the top row of buttons in the subtitle editor. You may need to configure `show = true` for subtitles in the `editor-settings.toml`.