### PR TITLE
Group minor dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,8 @@ updates:
     open-pull-requests-limit: 15
     labels:
       - type:dependencies
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
The goal of this patch is to make the monthly reviewing of dependency prs more efficient. It causes dependabot to group all minor and patch dependency updates into a single pull request. The reasoning is that minor updates are highly unlikely to cause our app to break or change and thus time can be saved by testing them all at once instead of individually.

Inspired by Opencast studio:
https://github.com/elan-ev/opencast-studio/blob/master/.github/dependabot.yml