### PR TITLE
GHA Workflow cleanups

### DIFF
--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -104,6 +104,7 @@ jobs:
 
   member:
     name: Check organization membership
+    if: github.repository_owner == 'opencast'
     runs-on: ubuntu-latest
 
     # Map a step output to a job output
@@ -134,6 +135,7 @@ jobs:
 
   translations:
     name: Translations only via Crowdin
+    if: github.repository_owner == 'opencast'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -24,7 +24,7 @@ jobs:
         ref: ${{github.event.pull_request.head.ref}}
         repository: ${{github.event.pull_request.head.repo.full_name}}
 
-    - name: Use Node.js 18.x
+    - name: Use Node.js 20.x
       uses: actions/setup-node@v4
       with:
         node-version: 20

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Checkout sources
       uses: actions/checkout@v4
 
-    - name: Use Node.js 18.x
+    - name: Use Node.js 20.x
       uses: actions/setup-node@v4
       with:
         node-version: 20

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   main:
+    if: github.repository_owner == 'opencast'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources


### PR DESCRIPTION
This PR applies a few, smaller changes
- **Only building and deploying if we're in the upstream repository**
- **Only update and deploying the test instance from the mainline repository.  The previous behaviour failed at the organization check for me.**
- **Name the correct version of node in use**

No functional changes, just additional pre-execution workflow checks, and updating the workflow's description to match its execution
