### PR TITLE
Changing the image-rendering of waveform images

### DIFF
--- a/src/main/Timeline.tsx
+++ b/src/main/Timeline.tsx
@@ -596,6 +596,7 @@ export const Waveforms: React.FC<{ timelineHeight: number; }> = ({ timelineHeigh
   const waveformStyle = css({
     background: `${theme.waveform_bg}`,
     borderRadius: "5px",
+    imageRendering: "pixelated",
   });
 
   // When the URLs to the videos are fetched, generate waveforms

--- a/src/main/TrackSelection.tsx
+++ b/src/main/TrackSelection.tsx
@@ -339,7 +339,7 @@ const AudioTrackItem: React.FC<{
         <img
           src={waveform ?? PlaceholderWaveform}
           css={imgStyle}
-          style={{ opacity: track.audio_stream.enabled ? "1" : "0.5" }}
+          style={{ opacity: track.audio_stream.enabled ? "1" : "0.5", imageRendering: "pixelated" }}
           alt="placeholder for audio stream"
         />
         :


### PR DESCRIPTION
fixes #1583

Large waveform images appear blurry in Chrome browsers. Changing the image rendering to "pixelated" for the waveforms helps to avoid this.

Example without `image-rendering: "pixelated"`:
![grafik](https://github.com/user-attachments/assets/c0ca33b5-4989-44e7-aed3-4b2aee8ee008)
![grafik](https://github.com/user-attachments/assets/bbe0ff1b-8827-4b98-835d-d4460dbfc082)

The same waveform with this PR:
![grafik](https://github.com/user-attachments/assets/a3d156f3-374f-4326-861f-e6fc6a21eaa3)
![grafik](https://github.com/user-attachments/assets/e4c3332b-19c9-489d-aed0-2e676344fd33)
