### PR TITLE
Add  "fullscreen" button

### DIFF
--- a/src/main/SubtitleVideoArea.tsx
+++ b/src/main/SubtitleVideoArea.tsx
@@ -142,6 +142,9 @@ const SubtitleVideoArea: React.FC<{
             subtitleUrl={subtitleUrl}
             first={true}
             last={true}
+            isFullscreenPossible={false}
+            fullscreenPlayerIndex={undefined}
+            setFullscreenPlayerIndex={() => {}}
             selectIsPlaying={selectIsPlaying}
             selectIsMuted={selectIsMuted}
             selectCurrentlyAtInSeconds={selectCurrentlyAtInSeconds}

--- a/src/main/VideoPlayers.tsx
+++ b/src/main/VideoPlayers.tsx
@@ -39,7 +39,7 @@ import { useTheme } from "../themes";
 import { backgroundBoxStyle, basicButtonStyle } from "../cssStyles";
 import { BaseReactPlayerProps } from "react-player/base";
 import { ErrorBox } from "@opencast/appkit";
-import { LuFullscreen } from "react-icons/lu";
+import { LuMaximize2, LuMinimize2 } from "react-icons/lu";
 import { isSafari } from "react-device-detect";
 
 const VideoPlayers: React.FC<{
@@ -500,6 +500,7 @@ export const VideoPlayer = React.forwardRef<VideoPlayerForwardRef, VideoPlayerPr
                   right: "10px",
                   cursor: "pointer",
                 })]}
+                aria-pressed={fullscreenPlayerIndex !== undefined}
                 onClick={() => {
                   if (fullscreenPlayerIndex === undefined) {
                     setFullscreenPlayerIndex(dataKey);
@@ -507,7 +508,9 @@ export const VideoPlayer = React.forwardRef<VideoPlayerForwardRef, VideoPlayerPr
                     setFullscreenPlayerIndex(undefined);
                   }
                 }}
-                ><LuFullscreen /></button>
+                >
+                  {fullscreenPlayerIndex === undefined ? <LuMaximize2 /> : <LuMinimize2 />}
+                </button>
               }
             </div>
           </div>

--- a/src/main/VideoPlayers.tsx
+++ b/src/main/VideoPlayers.tsx
@@ -498,6 +498,7 @@ export const VideoPlayer = React.forwardRef<VideoPlayerForwardRef, VideoPlayerPr
                   position: "absolute",
                   bottom: "10px",
                   right: "10px",
+                  cursor: "pointer",
                 })]}
                 onClick={() => {
                   if (fullscreenPlayerIndex === undefined) {

--- a/src/main/VideoPlayers.tsx
+++ b/src/main/VideoPlayers.tsx
@@ -40,6 +40,7 @@ import { backgroundBoxStyle, basicButtonStyle } from "../cssStyles";
 import { BaseReactPlayerProps } from "react-player/base";
 import { ErrorBox } from "@opencast/appkit";
 import { LuFullscreen } from "react-icons/lu";
+import { isSafari } from "react-device-detect";
 
 const VideoPlayers: React.FC<{
   refs?: React.MutableRefObject<(VideoPlayerForwardRef | null)[]>,
@@ -420,10 +421,37 @@ export const VideoPlayer = React.forwardRef<VideoPlayerForwardRef, VideoPlayerPr
 
     const shouldHide = fullscreenPlayerIndex !== undefined && fullscreenPlayerIndex !== dataKey;
 
+    // Because of Safari and the fact that it is not able to read and occupy based on rendered aspect ratio,
+    // We need to toggle the display, in order for Safari to update itself!
+    const initialVideoPlayerWrapperDisplay = isSafari ? "none" : "flex";
+    const [videoPlayerWrapperDisplay, setVideoPlayerWrapperDisplay] = useState(initialVideoPlayerWrapperDisplay);
+
+    useEffect(() => {
+      if (ready && isSafari) {
+        const timeout = setTimeout(() => {
+          setVideoPlayerWrapperDisplay("flex");
+        }, 10);
+        return () => clearTimeout(timeout);
+      }
+    }, [ready]);
+
+    // Watch fullscreenPlayerIndex and toggle display briefly, in order for Safari to update itself!
+    useEffect(() => {
+      if (fullscreenPlayerIndex !== undefined && isSafari) {
+        setVideoPlayerWrapperDisplay("none");
+        const timeout = setTimeout(() => {
+          setVideoPlayerWrapperDisplay("flex");
+        }, 10);
+        return () => clearTimeout(timeout);
+      }
+    }, [fullscreenPlayerIndex]);
+
     const videoPlayerWrapperStyles = css({
       height: "100%",
       width: "100%",
-      display: shouldHide ? "none" : "flex",
+      display: shouldHide ? "none" : videoPlayerWrapperDisplay,
+
+      flexGrow: "1",
 
       // For single video, center!
       ...(first && last) && { justifyContent: "center" },
@@ -450,7 +478,7 @@ export const VideoPlayer = React.forwardRef<VideoPlayerForwardRef, VideoPlayerPr
               <ReactPlayer url={url}
                 // css={[backgroundBoxStyle(theme), reactPlayerStyle]}  // moved to wrapper
                 ref={ref}
-                width="unset"
+                width="100%"
                 height="100%"
                 playing={isPlaying}
                 volume={volume}


### PR DESCRIPTION
Adds "fullscreen" buttons to the videos in the cutting tab.

The goal is to give users a simple way to zoom in on a video in case they need to perceive details, like for example small text on a blackboard.

![Bildschirmfoto vom 2025-05-20 10-49-34](https://github.com/user-attachments/assets/b3905d29-4bcb-4614-918b-bea9321d9f9b)
![Bildschirmfoto vom 2025-05-20 10-49-40](https://github.com/user-attachments/assets/860c1f55-1104-4d41-91f2-4c616118b527)
