### PR TITLE
Update GHA scripts to work properly

### DIFF
--- a/.github/get-release-server.sh
+++ b/.github/get-release-server.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 OC_VERSION"
+  echo " eg: $0 r/16.x -> Returns the current correct server for r/16.x"
+  exit 1
+fi
+
+git clone https://github.com/opencast/opencast.git ~/opencast
+cd ~/opencast
+
+#Get the list of *all* branches in the format remotes/origin/r/N.m
+#grep for r/N.x
+#then use cut to remove remotes/origin
+#then use sort, with a field delimiter of '/', sorting on the *second* key in 'n'umeric 'r'evers order
+#then only consider the first 3 entries
+ary=( develop `git branch -a | grep origin | grep 'r/[0-9]*.x' | cut -f 3- -d '/' | sort -t '/' -k 2nr | head -n 3` )
+
+#Iterate through the array above.
+#If the script input matches the first item, spit out develop
+#If the script iput matches hte second item... etc
+#If it doesn't match anything, then don't say anything
+for i in "${!ary[@]}"
+do
+  if [[ "${ary[i]}" = "$1" ]]; then
+    if [[ $i -eq 0 ]]; then
+      echo "develop.opencast.org"
+      exit 0
+    elif [[ $i -eq 1 ]]; then
+      echo "stable.opencast.org"
+      exit 0
+    elif [[ $i -eq 2 ]]; then
+      echo "legacy.opencast.org"
+      exit 0
+    fi
+  fi
+done

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -19,8 +19,18 @@ jobs:
           git config --global user.name 'Release Bot'
 
       - name: tag and push
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          export TEMP=${{ github.ref_name }}
+          #Translate 'develop' to 18.x or whatever is appropriate
+          if [ "develop" == "${{ github.ref_name }}" ]; then
+            #NB normally we only clone just the head ref, but fetch-depth: 0 above gets *all* the history
+            export TEMP="$((`git branch -a | grep r/ | cut -f 4 -d '/' | cut -f 1 -d '.'` + 1)).x"
+          else
+            export TEMP=${{ github.ref_name }}
+          fi
           export TAG=${TEMP#r\/}-`date +%Y-%m-%d`
           git tag $TAG
           git push origin $TAG
+          sleep 2
+          gh workflow run process-release.yml -r $TAG

--- a/.github/workflows/crowdin-upload-keys.yml
+++ b/.github/workflows/crowdin-upload-keys.yml
@@ -3,7 +3,8 @@ name: Crowdin » Upload keys
 on:
   push:
     branches:
-      - main
+      - develop
+      - r/*
 
 concurrency:
   group: crowdin

--- a/.github/workflows/playwright-test.yml
+++ b/.github/workflows/playwright-test.yml
@@ -6,8 +6,8 @@ on:
       - 'dependabot/**'
   pull_request:
     branches:
-      - main
-
+      - develop
+      - r/*
 jobs:
   test:
 

--- a/.github/workflows/process-release.yml
+++ b/.github/workflows/process-release.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Prepare GitHub SSH key
         env:
-          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+          DEPLOY_KEY: ${{ secrets.MODULE_PR_DEPLOY_KEY }}
         run: |
           install -dm 700 ~/.ssh/
           echo "${DEPLOY_KEY}" > ~/.ssh/id_ed25519

--- a/.github/workflows/process-release.yml
+++ b/.github/workflows/process-release.yml
@@ -35,11 +35,32 @@ jobs:
 
       - name: create release tarball
         working-directory: build
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           tar -czf "../oc-editor-$(git describe --tags).tar.gz" *
-          echo EDITOR_CHECKSUM=`sha256sum oc-editor-$(git describe --tags).tar.gz | cut -f 1 -d " "` >> $GITHUB_ENV
+          echo EDITOR_CHECKSUM=`sha256sum ../oc-editor-$(git describe --tags).tar.gz | cut -f 1 -d " "` >> $GITHUB_ENV
           echo EDITOR_TAG=$(git describe --tags) >> $GITHUB_ENV
-          echo BASE_BRANCH=$(git describe --tags | cut -c 1-4) >> $GITHUB_ENV
+          while read branchname
+          do
+            #branchname looks like 'develop' or 'r/17.x', the describe + cut looks like '17.x', so we prefix with r/
+            # NB: branchname == develop *should not match* anything so that we fall back to the if case below
+            if [ "$branchname" != "r/`git describe --tags | cut -f 1 -d -`" ]; then
+              continue
+            fi
+            echo "Base branch is $branchname"
+            BASE_BRANCH="$branchname"
+            echo "BASE_BRANCH=$branchname" >> $GITHUB_ENV
+            break
+          done <<< `gh api \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              /repos/opencast/opencast/branches?per_page=100 | \
+            jq -r '. | map(select(.name | match("r/[0-9]*.x|develop"))) | .[].name'`
+          if [ -z "${BASE_BRANCH}" ]; then
+            echo "Base branch is develop"
+            echo "BASE_BRANCH=develop" >> $GITHUB_ENV
+          fi
 
       - name: create new release
         uses: softprops/action-gh-release@v2
@@ -64,16 +85,11 @@ jobs:
 
       - name: Clone upstream repository
         run: |
-          #This token is an account wide token which allows creation of PRs and pushes.
-          #echo "GH_TOKEN=${{ secrets.ACCESS_TOKEN }}" >> token.txt
-          #gh auth login --with-token < token.txt
-          git clone -b r/$BASE_BRANCH "git@github.com:opencast/opencast.git" ~/opencast
+          git clone -b $BASE_BRANCH "git@github.com:opencast/opencast.git" ~/opencast
           cd ~/opencast
           git checkout -b t/editor-$EDITOR_TAG
 
       - name: Update the editor pom file
-        #env:
-        #  GH_TOKEN: ${{ github.token }}
         run: |
           cd ~/opencast
           sed -i "s#<editor.sha256>.*</editor.sha256>#<editor.sha256>$EDITOR_CHECKSUM</editor.sha256>#" modules/editor/pom.xml
@@ -84,4 +100,10 @@ jobs:
           #This token is an account wide token which allows creation of PRs and pushes.
           echo "${{ secrets.PR_TOKEN }}" > token.txt
           gh auth login --with-token < token.txt
-          gh pr create --title "Update $BASE_BRANCH Editor to $EDITOR_TAG" --label editor --label maintenance --body "Updating Opencast $BASE_BRANCH Editor module to [$EDITOR_TAG](https://github.com/opencast/opencast-editor/releases/tag/$EDITOR_TAG)" --head=opencast:t/editor-$EDITOR_TAG --base r/$BASE_BRANCH -R opencast/opencast
+          gh pr create \
+            --title "Update $BASE_BRANCH Editor to $EDITOR_TAG" \
+            --label editor --label maintenance \
+            --body "Updating Opencast $BASE_BRANCH Editor module to [$EDITOR_TAG](https://github.com/opencast/opencast-editor/releases/tag/$EDITOR_TAG)" \
+            --head=opencast:t/editor-$EDITOR_TAG \
+            --base $BASE_BRANCH \
+            -R opencast/opencast

--- a/.github/workflows/process-release.yml
+++ b/.github/workflows/process-release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: checkout code
         uses: actions/checkout@v4
 
-      - name: use node.js 20.x
+      - name: get node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/process-release.yml
+++ b/.github/workflows/process-release.yml
@@ -84,4 +84,4 @@ jobs:
           #This token is an account wide token which allows creation of PRs and pushes.
           echo "${{ secrets.PR_TOKEN }}" > token.txt
           gh auth login --with-token < token.txt
-          gh pr create --title "Update $BASE_BRANCH Editor to $EDITOR_TAG" --label editor --label maintenance --body "Updating Opencast $BASE_BRANCH Editor module to $EDITOR_TAG" --head=opencast:t/editor-$EDITOR_TAG --base r/$BASE_BRANCH -R opencast/opencast
+          gh pr create --title "Update $BASE_BRANCH Editor to $EDITOR_TAG" --label editor --label maintenance --body "Updating Opencast $BASE_BRANCH Editor module to [$EDITOR_TAG](https://github.com/opencast/opencast-editor/releases/tag/$EDITOR_TAG)" --head=opencast:t/editor-$EDITOR_TAG --base r/$BASE_BRANCH -R opencast/opencast

--- a/.github/workflows/process-release.yml
+++ b/.github/workflows/process-release.yml
@@ -100,13 +100,13 @@ jobs:
 
       - name: Clone upstream repository
         run: |
-          git clone -b ${{ needs.build.outputs.branch }} "git@github.com:${{ github.repository_owner }}/opencast.git" ~/opencast
-          cd ~/opencast
+          git clone -b ${{ needs.build.outputs.branch }} "git@github.com:${{ github.repository_owner }}/opencast.git" opencast
+          cd opencast
           git checkout -b t/editor-${{ needs.build.outputs.tag }}
 
       - name: Update the editor pom file
+        working-directory: opencast
         run: |
-          cd ~/opencast
           sed -i "s#<editor.sha256>.*</editor.sha256>#<editor.sha256>${{ needs.build.outputs.checksum }}</editor.sha256>#" modules/editor/pom.xml
           sed -i "s#<editor.url>.*</editor.url>#<editor.url>https://github.com/${{ github.repository_owner }}/opencast-editor/releases/download/${{ needs.build.outputs.tag }}/oc-editor-${{ needs.build.outputs.tag }}.tar.gz</editor.url>#" modules/editor/pom.xml
           git add modules/editor/pom.xml

--- a/.github/workflows/process-release.yml
+++ b/.github/workflows/process-release.yml
@@ -60,7 +60,7 @@ jobs:
           done <<< `gh api \
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              /repos/opencast/opencast/branches?per_page=100 | \
+              /repos/${{ github.repository_owner }}/opencast/branches?per_page=100 | \
             jq -r '. | map(select(.name | match("r/[0-9]*.x|develop"))) | .[].name'`
           if [ -z "${BASE_BRANCH}" ]; then
             echo "Base branch is develop"
@@ -100,7 +100,7 @@ jobs:
 
       - name: Clone upstream repository
         run: |
-          git clone -b ${{ needs.build.outputs.branch }} "git@github.com:opencast/opencast.git" ~/opencast
+          git clone -b ${{ needs.build.outputs.branch }} "git@github.com:${{ github.repository_owner }}/opencast.git" ~/opencast
           cd ~/opencast
           git checkout -b t/editor-${{ needs.build.outputs.tag }}
 
@@ -108,7 +108,7 @@ jobs:
         run: |
           cd ~/opencast
           sed -i "s#<editor.sha256>.*</editor.sha256>#<editor.sha256>${{ needs.build.outputs.checksum }}</editor.sha256>#" modules/editor/pom.xml
-          sed -i "s#<editor.url>.*</editor.url>#<editor.url>https://github.com/opencast/opencast-editor/releases/download/${{ needs.build.outputs.tag }}/oc-editor-${{ needs.build.outputs.tag }}.tar.gz</editor.url>#" modules/editor/pom.xml
+          sed -i "s#<editor.url>.*</editor.url>#<editor.url>https://github.com/${{ github.repository_owner }}/opencast-editor/releases/download/${{ needs.build.outputs.tag }}/oc-editor-${{ needs.build.outputs.tag }}.tar.gz</editor.url>#" modules/editor/pom.xml
           git add modules/editor/pom.xml
           git commit -m "Updating editor to ${{ needs.build.outputs.tag }}"
           git push origin t/editor-${{ needs.build.outputs.tag }}
@@ -118,7 +118,7 @@ jobs:
           gh pr create \
             --title "Update ${{ needs.build.outputs.branch }} Editor to ${{ needs.build.outputs.tag }}" \
             --label editor --label maintenance \
-            --body "Updating Opencast ${{ needs.build.outputs.branch }} Editor module to [${{ needs.build.outputs.tag }}](https://github.com/opencast/opencast-editor/releases/tag/${{ needs.build.outputs.tag }})" \
-            --head=opencast:t/editor-${{ needs.build.outputs.tag }} \
+            --body "Updating Opencast ${{ needs.build.outputs.branch }} Editor module to [${{ needs.build.outputs.tag }}](https://github.com/${{ github.repository_owner }}/opencast-editor/releases/tag/${{ needs.build.outputs.tag }})" \
+            --head=${{ github.repository_owner }}:t/editor-${{ needs.build.outputs.tag }} \
             --base ${{ needs.build.outputs.branch }} \
-            -R opencast/opencast
+            -R ${{ github.repository_owner }}/opencast

--- a/.github/workflows/process-release.yml
+++ b/.github/workflows/process-release.yml
@@ -11,6 +11,10 @@ jobs:
     name: Create release from tag
     if: github.repository_owner == 'opencast'
     runs-on: ubuntu-latest
+    outputs:
+      checksum: ${{ steps.tarball.outputs.checksum }}
+      tag: ${{ steps.tarball.outputs.tag }}
+      branch: ${{ steps.tarball.outputs.branch }}
     permissions:
       contents: write #for the release
       pull-requests: write #For the PR in the upstream repo
@@ -34,13 +38,14 @@ jobs:
         run: npm run build
 
       - name: create release tarball
+        id: tarball
         working-directory: build
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           tar -czf "../oc-editor-$(git describe --tags).tar.gz" *
-          echo EDITOR_CHECKSUM=`sha256sum ../oc-editor-$(git describe --tags).tar.gz | cut -f 1 -d " "` >> $GITHUB_ENV
-          echo EDITOR_TAG=$(git describe --tags) >> $GITHUB_ENV
+          echo checksum=`sha256sum ../oc-editor-$(git describe --tags).tar.gz | cut -f 1 -d " "` >> $GITHUB_OUTPUT
+          echo tag=$(git describe --tags) >> $GITHUB_OUTPUT
           while read branchname
           do
             #branchname looks like 'develop' or 'r/17.x', the describe + cut looks like '17.x', so we prefix with r/
@@ -50,7 +55,7 @@ jobs:
             fi
             echo "Base branch is $branchname"
             BASE_BRANCH="$branchname"
-            echo "BASE_BRANCH=$branchname" >> $GITHUB_ENV
+            echo "branch=$branchname" >> $GITHUB_OUTPUT
             break
           done <<< `gh api \
               -H "Accept: application/vnd.github+json" \
@@ -59,7 +64,7 @@ jobs:
             jq -r '. | map(select(.name | match("r/[0-9]*.x|develop"))) | .[].name'`
           if [ -z "${BASE_BRANCH}" ]; then
             echo "Base branch is develop"
-            echo "BASE_BRANCH=develop" >> $GITHUB_ENV
+            echo "branch=develop" >> $GITHUB_OUTPUT
           fi
 
       - name: create new release
@@ -69,6 +74,16 @@ jobs:
           fail_on_unmatched_files: true
           generate_release_notes: true
 
+  upstream-pr:
+    name: Create upstream PR to incorporate release
+    if: github.repository_owner == 'opencast'
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write #for the release
+      pull-requests: write #For the PR in the upstream repo
+
+    steps:
       - name: Prepare git
         run: |
           git config --global user.name "Release Bot"
@@ -85,25 +100,25 @@ jobs:
 
       - name: Clone upstream repository
         run: |
-          git clone -b $BASE_BRANCH "git@github.com:opencast/opencast.git" ~/opencast
+          git clone -b ${{ needs.build.outputs.branch }} "git@github.com:opencast/opencast.git" ~/opencast
           cd ~/opencast
-          git checkout -b t/editor-$EDITOR_TAG
+          git checkout -b t/editor-${{ needs.build.outputs.tag }}
 
       - name: Update the editor pom file
         run: |
           cd ~/opencast
-          sed -i "s#<editor.sha256>.*</editor.sha256>#<editor.sha256>$EDITOR_CHECKSUM</editor.sha256>#" modules/editor/pom.xml
-          sed -i "s#<editor.url>.*</editor.url>#<editor.url>https://github.com/opencast/opencast-editor/releases/download/$EDITOR_TAG/oc-editor-$EDITOR_TAG.tar.gz</editor.url>#" modules/editor/pom.xml
+          sed -i "s#<editor.sha256>.*</editor.sha256>#<editor.sha256>${{ needs.build.outputs.checksum }}</editor.sha256>#" modules/editor/pom.xml
+          sed -i "s#<editor.url>.*</editor.url>#<editor.url>https://github.com/opencast/opencast-editor/releases/download/${{ needs.build.outputs.tag }}/oc-editor-${{ needs.build.outputs.tag }}.tar.gz</editor.url>#" modules/editor/pom.xml
           git add modules/editor/pom.xml
-          git commit -m "Updating editor to $EDITOR_TAG"
-          git push origin t/editor-$EDITOR_TAG
+          git commit -m "Updating editor to ${{ needs.build.outputs.tag }}"
+          git push origin t/editor-${{ needs.build.outputs.tag }}
           #This token is an account wide token which allows creation of PRs and pushes.
           echo "${{ secrets.MODULE_PR_TOKEN }}" > token.txt
           gh auth login --with-token < token.txt
           gh pr create \
-            --title "Update $BASE_BRANCH Editor to $EDITOR_TAG" \
+            --title "Update ${{ needs.build.outputs.branch }} Editor to ${{ needs.build.outputs.tag }}" \
             --label editor --label maintenance \
-            --body "Updating Opencast $BASE_BRANCH Editor module to [$EDITOR_TAG](https://github.com/opencast/opencast-editor/releases/tag/$EDITOR_TAG)" \
-            --head=opencast:t/editor-$EDITOR_TAG \
-            --base $BASE_BRANCH \
+            --body "Updating Opencast ${{ needs.build.outputs.branch }} Editor module to [${{ needs.build.outputs.tag }}](https://github.com/opencast/opencast-editor/releases/tag/${{ needs.build.outputs.tag }})" \
+            --head=opencast:t/editor-${{ needs.build.outputs.tag }} \
+            --base ${{ needs.build.outputs.branch }} \
             -R opencast/opencast

--- a/.github/workflows/process-release.yml
+++ b/.github/workflows/process-release.yml
@@ -98,7 +98,7 @@ jobs:
           git commit -m "Updating editor to $EDITOR_TAG"
           git push origin t/editor-$EDITOR_TAG
           #This token is an account wide token which allows creation of PRs and pushes.
-          echo "${{ secrets.PR_TOKEN }}" > token.txt
+          echo "${{ secrets.MODULE_PR_TOKEN }}" > token.txt
           gh auth login --with-token < token.txt
           gh pr create \
             --title "Update $BASE_BRANCH Editor to $EDITOR_TAG" \

--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -91,9 +91,7 @@ jobs:
 
       - name: Clone repository
         run: |
-          git clone "git@github.com:${{ github.repository_owner }}/opencast-editor-test.git" ~/editor-test
-          cd ~/editor-test
-          git checkout gh-pages
+          git clone -b gh-pages "git@github.com:${{ github.repository_owner }}/opencast-editor-test.git" editor-test
 
       - name: Store build
         env:
@@ -103,10 +101,10 @@ jobs:
           cp -rv build/* ${DEPLOY_PATH}
 
       - name: Cleanup test repository
+        working-directory: editor-test
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          cd ~/editor-test
           wget https://raw.githubusercontent.com/${{ github.repository_owner }}/opencast-editor-test/main/.github/scripts/cleanup-deployments.sh
           bash cleanup-deployments.sh ${{ github.repository_owner }}/opencast-editor
           rm -f cleanup-deployments.sh
@@ -122,14 +120,14 @@ jobs:
           echo '</ul></body></html>' >> index.html
 
       - name: Commit new version
+        working-directory: editor-test
         run: |
-          cd ~/editor-test
           git add .
           git commit --amend -m "Build ${{ steps.build-path.outputs.build }}"
 
       - name: Push updates
+        working-directory: editor-test
         run: |
-          cd ~/editor-test
           git push origin gh-pages --force
 
       - name: Add comment with deployment location

--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Clone repository
         run: |
-          git clone "git@github.com:opencast/opencast-editor-test.git" ~/editor-test
+          git clone "git@github.com:${{ github.repository_owner }}/opencast-editor-test.git" ~/editor-test
           cd ~/editor-test
           git checkout gh-pages
 
@@ -112,7 +112,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           cd ~/editor-test
-          wget https://raw.githubusercontent.com/opencast/opencast-editor-test/main/.github/scripts/cleanup-deployments.sh
+          wget https://raw.githubusercontent.com/${{ github.repository_owner }}/opencast-editor-test/main/.github/scripts/cleanup-deployments.sh
           bash cleanup-deployments.sh ${{ github.repository_owner }}/opencast-editor
           rm -f cleanup-deployments.sh
           git add .

--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -1,4 +1,4 @@
-name: Test & Deploy
+name: Publish Pull Request Page
 
 on:
   pull_request_target:
@@ -47,7 +47,7 @@ jobs:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
-      - name: Use Node.js 20.x
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -107,16 +107,27 @@ jobs:
           | sed 's/^\(.*\)$/<li><a href=\1>\1<\/a><\/li>/' >> index.html
         echo '</ul></body></html>' >> index.html
 
+    - name: Cleanup test repository
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        cd ~/editor-test
+        wget https://raw.githubusercontent.com/opencast/opencast-editor-test/main/.github/scripts/cleanup-deployments.sh
+        bash cleanup-deployments.sh ${{ github.repository_owner }}/opencast-editor
+        rm -f cleanup-deployments.sh
+        git add .
+        #git commit -m "Removing test deployments for closed pull requests"
+
     - name: Commit new version
       run: |
         cd ~/editor-test
         git add .
-        git commit -m "Build ${{ steps.build-path.outputs.build }}"
+        git commit --amend -m "Build ${{ steps.build-path.outputs.build }}"
 
     - name: Push updates
       run: |
         cd ~/editor-test
-        git push origin gh-pages
+        git push origin gh-pages --force
 
     - name: Add comment with deployment location
       uses: thollander/actions-comment-pull-request@v3

--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -15,129 +15,129 @@ jobs:
       server: ${{ steps.test-server.outputs.server }}
       branch: ${{ steps.branch-name.outputs.branch }}
     steps:
-    - name: Checkout sources
-      uses: actions/checkout@v4
-      with:
-        ref: ${{github.event.pull_request.head.ref}}
-        repository: ${{github.event.pull_request.head.repo.full_name}}
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
 
-    - name: Determine the correct test server
-      id: test-server
-      run: echo "server=`./.github/get-release-server.sh ${{ github.ref_name }}`" >> $GITHUB_OUTPUT
+      - name: Determine the correct test server
+        id: test-server
+        run: echo "server=`./.github/get-release-server.sh ${{ github.ref_name }}`" >> $GITHUB_OUTPUT
 
-    - name: Determine branch name
-      id: branch-name
-      run: |
-        #Temp becomes something like r/17.x
-        export TEMP=${{ github.ref_name }}
-        #Strip the r/ prefix, giving us just 17.x.  If this is main/develop this does nothing
-        echo "branch=${TEMP#r\/}" >> $GITHUB_OUTPUT
+      - name: Determine branch name
+        id: branch-name
+        run: |
+          #Temp becomes something like r/17.x
+          export TEMP=${{ github.ref_name }}
+          #Strip the r/ prefix, giving us just 17.x.  If this is main/develop this does nothing
+          echo "branch=${TEMP#r\/}" >> $GITHUB_OUTPUT
 
   main:
     runs-on: ubuntu-latest
     needs: detect
     steps:
-    - name: generate build path
-      run: echo "build=${{github.event.number}}/$(date +%Y-%m-%d_%H-%M-%S)/" >> $GITHUB_OUTPUT
-      id: build-path
+      - name: generate build path
+        run: echo "build=${{github.event.number}}/$(date +%Y-%m-%d_%H-%M-%S)/" >> $GITHUB_OUTPUT
+        id: build-path
 
-    - name: Checkout Sources
-      uses: actions/checkout@v4
-      with:
-        ref: ${{github.event.pull_request.head.ref}}
-        repository: ${{github.event.pull_request.head.repo.full_name}}
+      - name: Checkout Sources
+        uses: actions/checkout@v4
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
 
-    - name: Use Node.js 20.x
-      uses: actions/setup-node@v4
-      with:
-        node-version: 20
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
 
-    - name: Clean install
-      run: npm ci
+      - name: Clean install
+        run: npm ci
 
-    - name: Build App
-      run: |
-        # This set the editor's datasource to the relevant test server
-        sed -i "s#develop.opencast.org#$SERVER#g" public/editor-settings.toml
-        npm run build
-      env:
-        SERVER: ${{needs.detect.outputs.server}}
-        PUBLIC_URL: ${{ steps.build-path.outputs.build }}
+      - name: Build App
+        run: |
+          # This set the editor's datasource to the relevant test server
+          sed -i "s#develop.opencast.org#$SERVER#g" public/editor-settings.toml
+          npm run build
+        env:
+          SERVER: ${{needs.detect.outputs.server}}
+          PUBLIC_URL: ${{ steps.build-path.outputs.build }}
 
-    - name: Prepare Git
-      run: |
-        git config --global user.name "Release Bot"
-        git config --global user.email "cloud@opencast.org"
+      - name: Prepare Git
+        run: |
+          git config --global user.name "Release Bot"
+          git config --global user.email "cloud@opencast.org"
 
-    - name: Prepare GitHub SSH key
-      env:
-        DEPLOY_KEY: ${{ secrets.DEPLOY_KEY_TEST }}
-      run: |
-        install -dm 700 ~/.ssh/
-        echo "${DEPLOY_KEY}" > ~/.ssh/id_ed25519
-        chmod 600 ~/.ssh/id_ed25519
-        ssh-keyscan github.com >> ~/.ssh/known_hosts
+      - name: Prepare GitHub SSH key
+        env:
+          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY_TEST }}
+        run: |
+          install -dm 700 ~/.ssh/
+          echo "${DEPLOY_KEY}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
 
-    - name: Wait for previous workflows to finish
-      uses: softprops/turnstyle@v2
-      with:
-        same-branch-only: false
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Wait for previous workflows to finish
+        uses: softprops/turnstyle@v2
+        with:
+          same-branch-only: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Clone repository
-      run: |
-        git clone "git@github.com:opencast/opencast-editor-test.git" ~/editor-test
-        cd ~/editor-test
-        git checkout gh-pages
+      - name: Clone repository
+        run: |
+          git clone "git@github.com:opencast/opencast-editor-test.git" ~/editor-test
+          cd ~/editor-test
+          git checkout gh-pages
 
-    - name: Store build
-      env:
-        DEPLOY_PATH: editor-test/${{ steps.build-path.outputs.build }}
-      run: |
-        mkdir -p "${HOME}/${DEPLOY_PATH}"
-        cp -rv build/* "${HOME}/${DEPLOY_PATH}"
+      - name: Store build
+        env:
+          DEPLOY_PATH: editor-test/${{ steps.build-path.outputs.build }}
+        run: |
+          mkdir -p "${HOME}/${DEPLOY_PATH}"
+          cp -rv build/* "${HOME}/${DEPLOY_PATH}"
 
-    - name: Generate index.html
-      run: |
-        cd ~/editor-test
-        echo '<html><body><ul>' > index.html
-        find . -maxdepth 2 -name '*_*' -type d \
-          | sort -r \
-          | sed 's/^\(.*\)$/<li><a href=\1>\1<\/a><\/li>/' >> index.html
-        echo '</ul></body></html>' >> index.html
+      - name: Generate index.html
+        run: |
+          cd ~/editor-test
+          echo '<html><body><ul>' > index.html
+          find . -maxdepth 2 -name '*_*' -type d \
+            | sort -r \
+            | sed 's/^\(.*\)$/<li><a href=\1>\1<\/a><\/li>/' >> index.html
+          echo '</ul></body></html>' >> index.html
 
-    - name: Cleanup test repository
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: |
-        cd ~/editor-test
-        wget https://raw.githubusercontent.com/opencast/opencast-editor-test/main/.github/scripts/cleanup-deployments.sh
-        bash cleanup-deployments.sh ${{ github.repository_owner }}/opencast-editor
-        rm -f cleanup-deployments.sh
-        git add .
-        #git commit -m "Removing test deployments for closed pull requests"
+      - name: Cleanup test repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          cd ~/editor-test
+          wget https://raw.githubusercontent.com/opencast/opencast-editor-test/main/.github/scripts/cleanup-deployments.sh
+          bash cleanup-deployments.sh ${{ github.repository_owner }}/opencast-editor
+          rm -f cleanup-deployments.sh
+          git add .
+          #git commit -m "Removing test deployments for closed pull requests"
 
-    - name: Commit new version
-      run: |
-        cd ~/editor-test
-        git add .
-        git commit --amend -m "Build ${{ steps.build-path.outputs.build }}"
+      - name: Commit new version
+        run: |
+          cd ~/editor-test
+          git add .
+          git commit --amend -m "Build ${{ steps.build-path.outputs.build }}"
 
-    - name: Push updates
-      run: |
-        cd ~/editor-test
-        git push origin gh-pages --force
+      - name: Push updates
+        run: |
+          cd ~/editor-test
+          git push origin gh-pages --force
 
-    - name: Add comment with deployment location
-      uses: thollander/actions-comment-pull-request@v3
-      with:
-        message: >
-          This pull request is deployed at
-          [test.editor.opencast.org/${{ steps.build-path.outputs.build }}
-          ](https://test.editor.opencast.org/${{ steps.build-path.outputs.build }}).
+      - name: Add comment with deployment location
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          message: >
+            This pull request is deployed at
+            [test.editor.opencast.org/${{ steps.build-path.outputs.build }}
+            ](https://test.editor.opencast.org/${{ steps.build-path.outputs.build }}).
 
-          It might take a few minutes for it to become available.
+            It might take a few minutes for it to become available.
 
 
   member:
@@ -177,20 +177,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout Sources
-      uses: actions/checkout@v4
+      - name: Checkout Sources
+        uses: actions/checkout@v4
 
-    - name: Get changed locale files
-      uses: dorny/paths-filter@v3
-      id: filter_locales
-      with:
-        filters: | # !(pattern) matches anything but pattern
-          locales:
-            - 'src/i18n/locales/!(en-US)*.json'
+      - name: Get changed locale files
+        uses: dorny/paths-filter@v3
+        id: filter_locales
+        with:
+          filters: | # !(pattern) matches anything but pattern
+            locales:
+              - 'src/i18n/locales/!(en-US)*.json'
 
-    - name: Check for changes in translations
-      if: steps.filter_locales.outputs.locales == true
-      uses: actions/github-script@v7
-      with:
-        script: |
-            core.setFailed('You should not alter translations outside of Crowdin.')
+      - name: Check for changes in translations
+        if: steps.filter_locales.outputs.locales == true
+        uses: actions/github-script@v7
+        with:
+          script: |
+              core.setFailed('You should not alter translations outside of Crowdin.')

--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -99,17 +99,8 @@ jobs:
         env:
           DEPLOY_PATH: editor-test/${{ steps.build-path.outputs.build }}
         run: |
-          mkdir -p "${HOME}/${DEPLOY_PATH}"
-          cp -rv build/* "${HOME}/${DEPLOY_PATH}"
-
-      - name: Generate index.html
-        run: |
-          cd ~/editor-test
-          echo '<html><body><ul>' > index.html
-          find . -maxdepth 2 -name '*_*' -type d \
-            | sort -r \
-            | sed 's/^\(.*\)$/<li><a href=\1>\1<\/a><\/li>/' >> index.html
-          echo '</ul></body></html>' >> index.html
+          mkdir -p ${DEPLOY_PATH}
+          cp -rv build/* ${DEPLOY_PATH}
 
       - name: Cleanup test repository
         env:
@@ -120,7 +111,15 @@ jobs:
           bash cleanup-deployments.sh ${{ github.repository_owner }}/opencast-editor
           rm -f cleanup-deployments.sh
           git add .
-          #git commit -m "Removing test deployments for closed pull requests"
+
+      - name: Generate index.html
+        working-directory: editor-test
+        run: |
+          echo '<html><body><ul>' > index.html
+          find . -maxdepth 2 -name '*_*' -type d \
+            | sort -r \
+            | sed 's/^\(.*\)$/<li><a href=\1>\1<\/a><\/li>/' >> index.html
+          echo '</ul></body></html>' >> index.html
 
       - name: Commit new version
         run: |

--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -6,6 +6,10 @@ on:
       - opened
       - synchronize
 
+concurrency:
+  group: pull-request-page
+  cancel-in-progress: false
+
 jobs:
   detect:
     if: ${{ needs.member.outputs.is_team_member == 'true'

--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -7,15 +7,38 @@ on:
       - synchronize
 
 jobs:
-  main:
+  detect:
     if: ${{ needs.member.outputs.is_team_member == 'true'
       || github.event.pull_request.head.repo.full_name == 'opencast/opencast-editor' }}
-    needs: member
     runs-on: ubuntu-latest
+    outputs:
+      server: ${{ steps.test-server.outputs.server }}
+      branch: ${{ steps.branch-name.outputs.branch }}
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v4
+      with:
+        ref: ${{github.event.pull_request.head.ref}}
+        repository: ${{github.event.pull_request.head.repo.full_name}}
 
+    - name: Determine the correct test server
+      id: test-server
+      run: echo "server=`./.github/get-release-server.sh ${{ github.ref_name }}`" >> $GITHUB_OUTPUT
+
+    - name: Determine branch name
+      id: branch-name
+      run: |
+        #Temp becomes something like r/17.x
+        export TEMP=${{ github.ref_name }}
+        #Strip the r/ prefix, giving us just 17.x.  If this is main/develop this does nothing
+        echo "branch=${TEMP#r\/}" >> $GITHUB_OUTPUT
+
+  main:
+    runs-on: ubuntu-latest
+    needs: detect
     steps:
     - name: generate build path
-      run: echo "::set-output name=build::${{github.event.number}}/$(date +%Y-%m-%d_%H-%M-%S)/" | sed 's_build::/*_build::_'
+      run: echo "build=${{github.event.number}}/$(date +%Y-%m-%d_%H-%M-%S)/" >> $GITHUB_OUTPUT
       id: build-path
 
     - name: Checkout Sources
@@ -33,9 +56,13 @@ jobs:
       run: npm ci
 
     - name: Build App
-      run: npm run build
+      run: |
+        # This set the editor's datasource to the relevant test server
+        sed -i "s#develop.opencast.org#$SERVER#g" public/editor-settings.toml
+        npm run build
       env:
-        PUBLIC_URL: /${{ steps.build-path.outputs.build }}
+        SERVER: ${{needs.detect.outputs.server}}
+        PUBLIC_URL: ${{ steps.build-path.outputs.build }}
 
     - name: Prepare Git
       run: |

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,9 +1,5 @@
-# This is a basic workflow to help you get started with Actions
+name: Build & Deploy main branches
 
-name: Build & Deploy
-
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
 on:
   push:
     branches:
@@ -44,7 +40,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
-      - name: Use Node.js 20.x
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -15,9 +15,31 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  main:
+  detect:
     if: github.repository_owner == 'opencast'
     runs-on: ubuntu-latest
+    outputs:
+      server: ${{ steps.test-server.outputs.server }}
+      branch: ${{ steps.branch-name.outputs.branch }}
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v4
+
+    - name: Determine the correct test server
+      id: test-server
+      run: echo "server=`./.github/get-release-server.sh ${{ github.ref_name }}`" >> $GITHUB_OUTPUT
+
+    - name: Determine branch name
+      id: branch-name
+      run: |
+        #Temp becomes something like r/17.x
+        export TEMP=${{ github.ref_name }}
+        #Strip the r/ prefix, giving us just 17.x.  If this is main/develop this does nothing
+        echo "branch=${TEMP#r\/}" >> $GITHUB_OUTPUT
+
+  main:
+    runs-on: ubuntu-latest
+    needs: detect
     steps:
     - name: Checkout sources
       uses: actions/checkout@v4
@@ -31,7 +53,14 @@ jobs:
       run: npm ci
 
     - name: Build App
-      run: npm run build
+      run: |
+        # This set the editor's datasource to the relevant test server
+        sed -i "s#develop.opencast.org#$SERVER#g" public/editor-settings.toml
+        npm run build
+      env:
+        SERVER: ${{needs.detect.outputs.server}}
+        PUBLIC_URL: ${{needs.detect.outputs.branch}}
+        VITE_APP_SETTINGS_PATH: editor-settings.toml
 
     # tests are currently failing
     #- run: npm test

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -7,7 +7,7 @@ on:
       - r/*
 
 concurrency:
-  group: editor.opencast.org
+  group: ${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -72,44 +72,25 @@ jobs:
         git config --global user.name "Release Bot"
         git config --global user.email "cloud@opencast.org"
 
-    - name: Prepare GitHub SSH key
-      env:
-        DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
-      run: |
-        install -dm 700 ~/.ssh/
-        echo "${DEPLOY_KEY}" > ~/.ssh/id_ed25519
-        chmod 600 ~/.ssh/id_ed25519
-        ssh-keyscan github.com >> ~/.ssh/known_hosts
-
-    - name: Clone repository
-      run: |
-        git clone "git@github.com:opencast/opencast-editor.git" ~/editor-clone
-        cd ~/editor-clone
-        git checkout gh-pages
-
     - name: Commit new version
       run: |
-        #Temp becomes something like r/17.x
-        export TEMP=${{ github.ref_name }}
-        #Strip the r/ prefix, giving us just 17.x.  If this is main/develop this does nothing
-        export TARGET=~/editor-clone/${TEMP#r\/}
+        git checkout -- public/editor-settings.toml
+        git fetch --unshallow origin gh-pages
+        git checkout gh-pages
         # Update gh-pages
-        rm -rf $TARGET
-        mkdir -p $TARGET
-        cp -r build/* $TARGET
-        # Add the new build to the repo
-        cd ~/editor-clone
+        rm -rf $BRANCH
+        mv build $BRANCH
         #Generate an index, in case anyone lands at the root of the test domain
         echo '<html><body><ul>' > index.html
         find . -mindepth 1 -maxdepth 1 -type d \
-          | grep -v .git \
+          | grep '[0-9]*.x\|develop' \
           | sort -r \
           | sed 's/^\(.*\)$/<li><a href=\1>\1<\/a><\/li>/' >> index.html
         echo '</ul></body></html>' >> index.html
-        git add ./*
+        git add $BRANCH index.html
         git diff --staged --quiet || git commit --amend -m "Build $(date)"
+      env:
+        BRANCH: ${{needs.detect.outputs.branch}}
 
     - name: Push updates
-      run: |
-        cd ~/editor-clone
-        git push origin gh-pages --force
+      run: git push origin gh-pages --force

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -22,75 +22,75 @@ jobs:
       server: ${{ steps.test-server.outputs.server }}
       branch: ${{ steps.branch-name.outputs.branch }}
     steps:
-    - name: Checkout sources
-      uses: actions/checkout@v4
+      - name: Checkout sources
+        uses: actions/checkout@v4
 
-    - name: Determine the correct test server
-      id: test-server
-      run: echo "server=`./.github/get-release-server.sh ${{ github.ref_name }}`" >> $GITHUB_OUTPUT
+      - name: Determine the correct test server
+        id: test-server
+        run: echo "server=`./.github/get-release-server.sh ${{ github.ref_name }}`" >> $GITHUB_OUTPUT
 
-    - name: Determine branch name
-      id: branch-name
-      run: |
-        #Temp becomes something like r/17.x
-        export TEMP=${{ github.ref_name }}
-        #Strip the r/ prefix, giving us just 17.x.  If this is main/develop this does nothing
-        echo "branch=${TEMP#r\/}" >> $GITHUB_OUTPUT
+      - name: Determine branch name
+        id: branch-name
+        run: |
+          #Temp becomes something like r/17.x
+          export TEMP=${{ github.ref_name }}
+          #Strip the r/ prefix, giving us just 17.x.  If this is main/develop this does nothing
+          echo "branch=${TEMP#r\/}" >> $GITHUB_OUTPUT
 
   main:
     runs-on: ubuntu-latest
     needs: detect
     steps:
-    - name: Checkout sources
-      uses: actions/checkout@v4
+      - name: Checkout sources
+        uses: actions/checkout@v4
 
-    - name: Use Node.js 20.x
-      uses: actions/setup-node@v4
-      with:
-        node-version: 20
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
 
-    - name: Clean install
-      run: npm ci
+      - name: Clean install
+        run: npm ci
 
-    - name: Build App
-      run: |
-        # This set the editor's datasource to the relevant test server
-        sed -i "s#develop.opencast.org#$SERVER#g" public/editor-settings.toml
-        npm run build
-      env:
-        SERVER: ${{needs.detect.outputs.server}}
-        PUBLIC_URL: ${{needs.detect.outputs.branch}}
-        VITE_APP_SETTINGS_PATH: editor-settings.toml
+      - name: Build App
+        run: |
+          # This set the editor's datasource to the relevant test server
+          sed -i "s#develop.opencast.org#$SERVER#g" public/editor-settings.toml
+          npm run build
+        env:
+          SERVER: ${{needs.detect.outputs.server}}
+          PUBLIC_URL: ${{needs.detect.outputs.branch}}
+          VITE_APP_SETTINGS_PATH: editor-settings.toml
 
-    # tests are currently failing
-    #- run: npm test
-    #  env:
-    #    CI: true
+      # tests are currently failing
+      #- run: npm test
+      #  env:
+      #    CI: true
 
-    - name: Prepare git
-      run: |
-        git config --global user.name "Release Bot"
-        git config --global user.email "cloud@opencast.org"
+      - name: Prepare git
+        run: |
+          git config --global user.name "Release Bot"
+          git config --global user.email "cloud@opencast.org"
 
-    - name: Commit new version
-      run: |
-        git checkout -- public/editor-settings.toml
-        git fetch --unshallow origin gh-pages
-        git checkout gh-pages
-        # Update gh-pages
-        rm -rf $BRANCH
-        mv build $BRANCH
-        #Generate an index, in case anyone lands at the root of the test domain
-        echo '<html><body><ul>' > index.html
-        find . -mindepth 1 -maxdepth 1 -type d \
-          | grep '[0-9]*.x\|develop' \
-          | sort -r \
-          | sed 's/^\(.*\)$/<li><a href=\1>\1<\/a><\/li>/' >> index.html
-        echo '</ul></body></html>' >> index.html
-        git add $BRANCH index.html
-        git diff --staged --quiet || git commit --amend -m "Build $(date)"
-      env:
-        BRANCH: ${{needs.detect.outputs.branch}}
+      - name: Commit new version
+        run: |
+          git checkout -- public/editor-settings.toml
+          git fetch --unshallow origin gh-pages
+          git checkout gh-pages
+          # Update gh-pages
+          rm -rf $BRANCH
+          mv build $BRANCH
+          #Generate an index, in case anyone lands at the root of the test domain
+          echo '<html><body><ul>' > index.html
+          find . -mindepth 1 -maxdepth 1 -type d \
+            | grep '[0-9]*.x\|develop' \
+            | sort -r \
+            | sed 's/^\(.*\)$/<li><a href=\1>\1<\/a><\/li>/' >> index.html
+          echo '</ul></body></html>' >> index.html
+          git add $BRANCH index.html
+          git diff --staged --quiet || git commit --amend -m "Build $(date)"
+        env:
+          BRANCH: ${{needs.detect.outputs.branch}}
 
-    - name: Push updates
-      run: git push origin gh-pages --force
+      - name: Push updates
+        run: git push origin gh-pages --force

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -7,7 +7,7 @@ name: Build & Deploy
 on:
   push:
     branches:
-      - main
+      - develop
       - r/*
 
 concurrency:

--- a/.github/workflows/vitest-test.yml
+++ b/.github/workflows/vitest-test.yml
@@ -6,7 +6,8 @@ on:
       - 'dependabot/**'
   pull_request:
     branches:
-      - main
+      - develop
+      - r/*
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -93,25 +93,29 @@ How to cut a release for Opencast
 ---------------------------------
 
 1. (Optional) Run the [Update translations](https://github.com/opencast/opencast-editor/actions/workflows/update-translations.yml) workflow, to make sure all changes from crowdin are included in the next release.
-1. Switch to the commit you want to turn into the release
+1. Run the [Create release tag](https://github.com/opencast/opencast-editor/actions/workflows/create-release.yml) workflow from the branch you want to release.
+    - This will create the tag in the forman N.x-YYYY-MM-DD
+    - It will then create a new [GitHub release](https://github.com/opencast/opencast-editor/releases)
+        - Review and edit the release to make sure the release notes are correct
+            - By selecting the previous release, Github can generate release notes automatically
+    - Finally it will create an upstream PR to the relevant [Opencast](http://github.com/opencast/opencast) branch incorporating the new release
+
+Cutting manually
+
+1. Switch to the commit you want to turn into the release - make sure this is the on `develop` or an `r/N.x` branch
 1. Create and push a new tag
    ```bash
+    BRANCH=N.x (make sure the version you write here matches the branch you have checked out)
     DATE=$(date +%Y-%m-%d)
-    git tag -m Release -s "$DATE"
-    git push upstream "$DATE":"$DATE"
+    git tag -m "Release $BRANCH-$DATE" -s "$BRANCH-$DATE"
+    git push upstream "$BRANCH-$DATE":"$BRANCH-$DATE"
    ```
-1. Wait for the [Create release draft](https://github.com/opencast/opencast-editor/actions/workflows/create-release.yml)
+1. Wait for the [Create release](https://github.com/opencast/opencast-editor/actions/workflows/process-release.yml)
    workflow to finish
-    - It will create a new [GitHub release draft](https://github.com/opencast/opencast-editor/releases)
-    - Review and publish the draft
-        - By selecting the previous release, Github can generate release notes automatically
-1. Submit a pull request against Opencast
-    - [Update the release](https://github.com/opencast/opencast/blob/b2bea8822b95b8692bb5bbbdf75c9931c2b7298a/modules/editor/pom.xml#L16-L17)
-    - [Adjust the documentation](https://github.com/opencast/opencast/blob/b2bea8822b95b8692bb5bbbdf75c9931c2b7298a/docs/guides/admin/docs/modules/editor.md)
-      if necessary
-    - [Update the configuration](https://github.com/opencast/opencast/blob/b2bea8822b95b8692bb5bbbdf75c9931c2b7298a/etc/ui-config/mh_default_org/editor/editor-settings.toml)
-      if necessary
-    - Verify that the new release runs in Opencast, then create the pull request.
+    - It will then create a new [GitHub release](https://github.com/opencast/opencast-editor/releases)
+        - Review and edit the release to make sure the release notes are correct
+            - By selecting the previous release, Github can generate release notes automatically
+    - Finally it will create an upstream PR to the relevant [Opencast](http://github.com/opencast/opencast) branch incorporating the new release
 
 
 Opencast API used by the Editor


### PR DESCRIPTION
The initial PR pulling the workflow changes into the upstream repo contained a number of flaws that this corrects:

- We now detect the branch version, and target appropriate test infrastructure (ie, stable against stable.opencast.org) for test deploys and PRs
- Releases now build against the correct branch
- Release process has now been documented, and simplified
- Using `git amend`, we now update the test instances backed by the `gh-pages` branch without keeping its history.  This will entail a manual force-push to remove the history after this PR goes in.  Likewise, I will be eliminating the history in `opencast-editor-test`.
- Fixed a number of minor bugs
