### PR TITLE
Remove labels from release PRs

### DIFF
--- a/.github/workflows/process-release.yml
+++ b/.github/workflows/process-release.yml
@@ -117,7 +117,9 @@ jobs:
           gh auth login --with-token < token.txt
           gh pr create \
             --title "Update ${{ needs.build.outputs.branch }} Editor to ${{ needs.build.outputs.tag }}" \
-            --label editor --label maintenance \
+            #FIXME: fine grained PATs can't apply labels
+            #FIXME: classic PATs don't have the permissions because the PR isn't in an opencastproject (the user) repo
+            #--label editor --label maintenance \
             --body "Updating Opencast ${{ needs.build.outputs.branch }} Editor module to [${{ needs.build.outputs.tag }}](https://github.com/${{ github.repository_owner }}/opencast-editor/releases/tag/${{ needs.build.outputs.tag }})" \
             --head=${{ github.repository_owner }}:t/editor-${{ needs.build.outputs.tag }} \
             --base ${{ needs.build.outputs.branch }} \


### PR DESCRIPTION
From the commit message:

As described in the workflow, the two types of available PATs do not
allow the ghcli to add tags (or modify the PR at all after filing).  The
new, fine grained tokens should, at least in theory. This appears to
still be broken after more than a year.  The classic PATs complain that
the user does not have permission to update the PR.  In testing this on
my account, the classic PAT works correctly, so I suspect what we're
seeing here is that the generated PR is in the Opencast (project)'s
namespace, where the user generating the PR is opencastproject - an
entirely separate entity than the organization.  Also, the organization
can't run workflows, so we can't do it that way either.

Fun times.
