### PR TITLE
Switch icon with arrows for hourglass

### DIFF
--- a/src/main/Cutting.tsx
+++ b/src/main/Cutting.tsx
@@ -26,7 +26,7 @@ import { useTheme } from "../themes";
 import { setError } from "../redux/errorSlice";
 import { selectTitleFromEpisodeDc } from "../redux/metadataSlice";
 import { titleStyle, titleStyleBold, videosStyle } from "../cssStyles";
-import { LuMoveHorizontal } from "react-icons/lu";
+import { LuHourglass } from "react-icons/lu";
 import { css } from "@emotion/react";
 import VideoPlayers from "./VideoPlayers";
 import VideoControls from "./VideoControls";
@@ -56,7 +56,7 @@ const Cutting: React.FC = () => {
           error: true,
           errorTitle: t("error.workflowActive-errorTitle"),
           errorMessage: t("error.workflowActive-errorMessage"),
-          errorIcon: LuMoveHorizontal,
+          errorIcon: LuHourglass,
         }));
       } else {
         dispatch(setError({


### PR DESCRIPTION
Fixes #1598 

Changes the icon that is displayed when the editor is opened on an event on which a workflow is currently running, as suggested in #1598.

### How to test this

Open an event in the editor. Start a workflow on the event. Refresh the editor.