### PR TITLE
Reduce rerenders in the metadata tab

### DIFF
--- a/src/cssStyles.tsx
+++ b/src/cssStyles.tsx
@@ -171,9 +171,7 @@ type MyOptionType = {
   value: string;
 };
 
-type IsMulti = false;
-
-export function selectFieldStyle(theme: Theme): StylesConfig<MyOptionType, IsMulti> {
+export function selectFieldStyle<IsMulti extends boolean, >(theme: Theme): StylesConfig<MyOptionType, IsMulti> {
   return {
     control: (provided, state) => ({
       ...provided,

--- a/src/main/Cutting.tsx
+++ b/src/main/Cutting.tsx
@@ -30,6 +30,7 @@ import { LuMoveHorizontal } from "react-icons/lu";
 import { css } from "@emotion/react";
 import VideoPlayers from "./VideoPlayers";
 import VideoControls from "./VideoControls";
+import { fetchMetadata, selectGetStatus as selectMetadataGetStatus } from "../redux/metadataSlice";
 
 const Cutting: React.FC = () => {
 
@@ -45,6 +46,7 @@ const Cutting: React.FC = () => {
   const theme = useTheme();
   const errorReason = useAppSelector((state: { videoState: { errorReason: httpRequestState["errorReason"]; }; }) =>
     state.videoState.errorReason);
+  const metadataGetStatus = useAppSelector(selectMetadataGetStatus);
 
   // Try to fetch URL from external API
   useEffect(() => {
@@ -75,6 +77,13 @@ const Cutting: React.FC = () => {
       }
     }
   }, [videoURLStatus, dispatch, error, t, errorReason, duration]);
+
+  // Already try fetching Metadata to reduce wait time
+  useEffect(() => {
+    if (metadataGetStatus === "idle") {
+      dispatch(fetchMetadata());
+    }
+  }, [metadataGetStatus, dispatch]);
 
   // Style
   const cuttingStyle = css({

--- a/src/main/Metadata.tsx
+++ b/src/main/Metadata.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 
 import { css } from "@emotion/react";
 import { BREAKPOINTS, calendarStyle, selectFieldStyle, titleStyle, titleStyleBold } from "../cssStyles";
@@ -286,10 +286,22 @@ const FieldContent: React.FC<{ field: MetadataField, readonly?: boolean }> = ({ 
     }
   };
 
+  const handleDateConversion = useCallback((value: string) => {
+    let returnValue = value;
+    if (field && (field.type === "date" || field.type === "time")) {
+      if (returnValue !== "") { // Empty string is allowed
+        returnValue = new Date(returnValue).toJSON();
+      }
+    }
+    return returnValue;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [field?.type]);
+
   // Set value in store, but debounced
   const debouncedCommit = useMemo(
     () =>
       debounce((newValue: string) => {
+        newValue = handleDateConversion(newValue);
         if (newValue !== field.value) {
           dispatch(
             setFieldValue({
@@ -299,7 +311,7 @@ const FieldContent: React.FC<{ field: MetadataField, readonly?: boolean }> = ({ 
           );
         }
       }, 500),
-    [dispatch, field.id, field.value],
+    [dispatch, field.id, field.value, handleDateConversion],
   );
 
   useEffect(() => {

--- a/src/main/Metadata.tsx
+++ b/src/main/Metadata.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 
 import { css } from "@emotion/react";
 import { BREAKPOINTS, calendarStyle, selectFieldStyle, titleStyle, titleStyleBold } from "../cssStyles";
@@ -6,16 +6,15 @@ import { BREAKPOINTS, calendarStyle, selectFieldStyle, titleStyle, titleStyleBol
 import { useAppDispatch, useAppSelector } from "../redux/store";
 import {
   fetchMetadata,
-  selectCatalogs,
-  Catalog,
   MetadataField,
   setFieldValue,
-  selectGetError,
   selectGetStatus,
-  setFieldReadonly,
+  selectCatalogIds,
+  selectCatalogById,
+  selectFieldById,
+  selectGetError,
 } from "../redux/metadataSlice";
 
-import { Form, Field, FieldInputProps } from "react-final-form";
 import Select from "react-select";
 import CreatableSelect from "react-select/creatable";
 
@@ -25,72 +24,35 @@ import { DateTime as LuxonDateTime } from "luxon";
 import { configureFieldsAttributes, settings } from "../config";
 import { useTheme } from "../themes";
 import { ThemeProvider } from "@mui/material/styles";
-import { cloneDeep } from "lodash";
 import { ParseKeys } from "i18next";
 import { ErrorBox } from "@opencast/appkit";
 import { screenWidthAtMost } from "@opencast/appkit";
+import { debounce } from "lodash";
 
 /**
- * Creates a Metadata form
- *
- * Takes data from a redux slice and throws it into a react-final-form.
- * When submitting, the state in the redux slice gets updated
- *
- * If something doesn"t work, main places of interest are the submit function
- * and the initialValues function
+ * The root component for Metadata
  */
 const Metadata: React.FC = () => {
-
-  const { t, i18n } = useTranslation();
-
-  // Init redux variables
   const dispatch = useAppDispatch();
-  const catalogs = useAppSelector(selectCatalogs);
   const getStatus = useAppSelector(selectGetStatus);
-  const getError = useAppSelector(selectGetError);
-  const theme = useTheme();
 
-  // Try to fetch URL from external API
   useEffect(() => {
     if (getStatus === "idle") {
       dispatch(fetchMetadata());
     }
   }, [getStatus, dispatch]);
 
-  // Overwrite readonly property of fields based on config settings
-  useEffect(() => {
-    if (getStatus === "success") {
-      for (let catalogIndex = 0; catalogIndex < catalogs.length; catalogIndex++) {
-        if (settings.metadata.configureFields) {
-          const configureFields = settings.metadata.configureFields;
-          const catalog = catalogs[catalogIndex];
+  return (<Catalogs />);
+};
 
-          if (catalog.title in configureFields) {
-            if (Object.keys(configureFields[catalog.title]).length > 0) {
-              const configureFieldsCatalog = configureFields[catalog.title];
-
-              for (let fieldIndex = 0; fieldIndex < catalog.fields.length; fieldIndex++) {
-                if (catalog.fields[fieldIndex].id in configureFieldsCatalog) {
-                  if ("readonly" in configureFieldsCatalog[catalog.fields[fieldIndex].id]) {
-                    dispatch(setFieldReadonly({
-                      catalogIndex: catalogIndex, fieldIndex: fieldIndex,
-                      value: configureFieldsCatalog[catalog.fields[fieldIndex].id].readonly,
-                    }));
-                  }
-                }
-              }
-            } else {
-              return undefined;
-            }
-          }
-        }
-      }
-    }
-  }, [getStatus, catalogs, dispatch]);
-
-  /**
-   * CSS
-   */
+/**
+ * Create catalog components or display error message
+ */
+const Catalogs: React.FC = () => {
+  const { t } = useTranslation();
+  const catalogIds = useAppSelector(selectCatalogIds);   // array of IDs (strings)
+  const getStatus = useAppSelector(selectGetStatus);
+  const getError = useAppSelector(selectGetError);
 
   const metadataStyle = css({
     padding: "20px",
@@ -106,6 +68,44 @@ const Metadata: React.FC = () => {
     },
   });
 
+  return (
+    <div css={metadataStyle}>
+      {getStatus === "failed" &&
+        <ErrorBox>
+          <span css={{ whiteSpace: "pre-line" }}>
+            {"A problem occurred during communication with Opencast. \n"}
+            {getError ?
+              t("various.error-details-text", { errorMessage: getError }) : undefined
+            }
+          </span>
+        </ErrorBox>
+      }
+
+      {catalogIds.map(id => (
+        <Catalog key={id} id={id} />
+      ))}
+    </div>
+  );
+};
+
+interface Props { id: string }
+/**
+ * A catalog created field components
+ */
+const Catalog: React.FC<Props> = ({ id }) => {
+  const { t, i18n } = useTranslation();
+  const theme = useTheme();
+
+  const catalog = useAppSelector(state => selectCatalogById(state, id));
+  if (!catalog) { return null; }
+
+  // eslint-disable-next-line max-len
+  const catalogConfig = settings.metadata.configureFields ? settings.metadata.configureFields[catalog.title] : undefined;
+  // If there are no fields for a given catalog, do not render
+  if (catalogConfig && Object.keys(catalogConfig).length <= 0) {
+    return null;
+  }
+
   const catalogStyle = css({
     background: `${theme.menu_background}`,
     borderRadius: "5px",
@@ -114,6 +114,47 @@ const Metadata: React.FC = () => {
     boxSizing: "border-box",
     padding: "10px",
   });
+
+  return (
+    <section css={catalogStyle}>
+      <div css={[titleStyle(theme), titleStyleBold(theme)]}>
+        {i18n.exists(`metadata.${catalog.title.replaceAll(".", "-")}`) ?
+          t(`metadata.${catalog.title.replaceAll(".", "-")}` as ParseKeys) : catalog.title
+        }
+      </div>
+      {catalog.fieldIds.map(fid => {
+        return <Field key={fid} id={fid} catalogConfig={catalogConfig}/>;
+      })}
+    </section>
+  );
+};
+
+
+interface FieldProps {
+  id: string,
+  catalogConfig: { [key: string]: configureFieldsAttributes } | undefined
+}
+/**
+ * A field has a label, content and validation
+ */
+const Field: React.FC<FieldProps> = ({ id, catalogConfig }) => {
+  const { t, i18n } = useTranslation();
+  const theme = useTheme();
+
+  const field = useAppSelector(state => selectFieldById(state, id));
+  if (!field) { return null; }
+
+  // If configured to not display this field, don't display this field
+  if (catalogConfig && field.name in catalogConfig && "show" in catalogConfig[field.name]) {
+    if (!catalogConfig[field.name].show) {
+      return null;
+    }
+  }
+
+  let readonly: boolean | undefined = undefined;
+  if (catalogConfig && field.name in catalogConfig && "readonly" in catalogConfig[field.name]) {
+    readonly = catalogConfig[field.name].readonly;
+  }
 
   const fieldStyle = css({
     display: "flex",
@@ -136,6 +177,146 @@ const Metadata: React.FC = () => {
     color: `${theme.metadata_highlight}`,
   });
 
+  return (
+    <div css={fieldStyle} data-testid={field.name}>
+      <label css={fieldLabelStyle}>
+        <>{
+          i18n.exists(`metadata.labels.${field.name}`) ?
+            t(`metadata.labels.${field.name}` as ParseKeys) : field.name
+        }</>
+        {field.required &&
+          <span css={fieldLabelRequiredStyle}>
+            {t("metadata.required")}
+          </span>
+        }
+      </label>
+
+      <FieldContent field={field} readonly={readonly} />
+      <FieldValidation field={field} />
+    </div>
+  );
+};
+
+/**
+ * Different input interfaces for fields
+ */
+const FieldContent: React.FC<{ field: MetadataField, readonly?: boolean }> = ({ field, readonly }) => {
+  const { t, i18n } = useTranslation();
+  const dispatch = useAppDispatch();
+  const theme = useTheme();
+
+  const [localValue, setLocalValue] = useState(field.value ?? "");
+  const isMulti = Array.isArray(field.value);
+  if (readonly === undefined) {
+    readonly = field.readOnly;
+  }
+
+  useEffect(() => {
+    // <input type="datetime-local"> is picky about its value and won"t accept
+    // global datetime strings, so we have to convert them to local ourselves.
+    if ((field.type === "date" || field.type === "time") && field.value !== "") {
+      // field = cloneDeep(field);
+      const leDate = new Date(field.value);
+      leDate.setMinutes(leDate.getMinutes() - leDate.getTimezoneOffset());
+      // field.value = leDate.toISOString().slice(0, 16);
+      setLocalValue(leDate.toISOString().slice(0, 16));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  /**
+   * Transforms field values and labels into an array of objects
+   * that can be parsed by react-select
+   * @param field
+   */
+  const generateReactSelectLibrary = (field: MetadataField) => {
+    if (field.collection) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const library: { value: any, label: string }[] = [];
+      Object.entries(field.collection).forEach(([key, value]) => {
+        // Parse Label
+        let descLabel = null;
+        if (i18n.exists(`metadata.${field.name}`)) {
+          descLabel = t(`metadata.${field.name}.${key.replaceAll(".", "-")}` as ParseKeys);
+
+          if (field.name === "license") {
+            descLabel = t(`metadata.${field.name}.${JSON.parse(key).label.replaceAll(".", "-")}` as ParseKeys);
+          }
+        }
+
+        // Change label for series
+        if (field.name === "isPartOf") {
+          descLabel = key;
+        }
+
+        // Add to library
+        library.push({
+          value: value,
+          label: descLabel ? descLabel : value,
+        });
+      });
+      library.sort((a, b) => a.label.localeCompare(b.label));
+      library.unshift({ value: "", label: "No value" });
+      return library;
+    } else {
+      return [];
+    }
+  };
+
+  const selectOptions = field.collection
+    ? generateReactSelectLibrary(field)
+    : [];
+
+
+  const currentSelectValue = isMulti
+    ? selectOptions.filter(opt => (localValue as unknown as string[]).includes(opt.value))
+    : selectOptions.find(opt => opt.value === localValue);
+
+  const handleTextChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setLocalValue(e.target.value);
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const handleSelectChange = (selected: any) => {
+    if (isMulti) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      setLocalValue(selected?.map((s: any) => s.value) ?? []);
+    } else {
+      setLocalValue(selected?.value ?? "");
+    }
+  };
+
+  // Set value in store, but debounced
+  const debouncedCommit = useMemo(
+    () =>
+      debounce((newValue: string) => {
+        if (newValue !== field.value) {
+          dispatch(
+            setFieldValue({
+              id: field.id,
+              value: newValue,
+            }),
+          );
+        }
+      }, 500),
+    [dispatch, field.id, field.value],
+  );
+
+  useEffect(() => {
+    debouncedCommit(localValue);
+    return () => {
+      debouncedCommit.cancel();
+    };
+  }, [localValue, debouncedCommit]);
+
+  // Trigger debounce NOW (for onBlur)
+  const commitImmediately = () => {
+    debouncedCommit.flush();
+  };
+
+  /**
+   * CSS
+   */
   const fieldTypeStyle = (isReadOnly: boolean) => {
     return css({
       fontSize: "1em",
@@ -165,120 +346,116 @@ const Metadata: React.FC = () => {
     );
   };
 
-  const validateStyle = (isError: boolean) => {
-    return css({
-      lineHeight: "32px",
-      marginLeft: "10px",
-      ...(isError && { color: `${theme.error}` }),
-      fontWeight: "bold",
-    });
-  };
-
-  // const buttonContainerStyle = css({
-  //   display: "flex",
-  //   flexFlow: "row nowrap",
-  //   justifyContent: "space-around",
-  //   marginTop: "25px",
-  // })
-
-  // // TODO: Rework all div buttons so the ":enabled" pseudo-class does not screw them over
-  // const basicButtonStyleCOPY = css({
-  //   borderRadius: "10px",
-  //   cursor: "pointer",
-  //   // Animation
-  //   transitionDuration: "0.3s",
-  //   transitionProperty: "transform",
-  //   "&:hover:enabled": {
-  //     transform: "scale(1.1)",
-  //   },
-  //   "&:focus:enabled": {
-  //     transform: "scale(1.1)",
-  //   },
-  //   "&:active:enabled": {
-  //     transform: "scale(0.9)",
-  //   },
-  //   // Flex position child elements
-  //   display: "flex",
-  //   justifyContent: "center",
-  //   alignItems: "center",
-  //   gap: "10px",
-  //   textAlign: "center" as const,
-  // });
-
-  // const submitButtonStyle = css({
-  //   background: "snow",
-  //   border: "1px solid #ccc",
-
-  //   "&[disabled]": {
-  //     opacity: "0.6",
-  //     cursor: "not-allowed",
-  //   },
-  // })
-
   /**
-   * Form Callbacks - Other
+   * Render
    */
-
-  /**
-    * Recursively recreates nested array structures for form initalValues
-    * @param library
-    * @param input
-    * @param output
-    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const helperHandleArrays = (library: any[] | null, input: string, output: any[]) => {
-    // If the value is hid inside an array, we need to extract it
-    if (Array.isArray(input)) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      input.forEach((subArray: any) => {
-        output.push(helperHandleArrays(library, subArray, output));
-      });
+  // input.id = input.name;
+  if (field.collection) {
+    if (Array.isArray(field.value)) {
+      return (
+        <CreatableSelect
+          onChange={handleSelectChange}
+          onBlur={commitImmediately}
+          value={currentSelectValue}
+          isMulti
+          isClearable={!readonly}     // The component does not support readOnly, so we have to work around
+          isSearchable={!readonly}    // by setting other settings
+          openMenuOnClick={!readonly}
+          menuIsOpen={readonly ? false : undefined}
+          options={generateReactSelectLibrary(field)}
+          styles={selectFieldStyle(theme)}
+          name={field.name}
+          css={fieldTypeStyle(readonly)}>
+        </CreatableSelect>
+      );
+    } else {
+      return (
+        <Select
+          onChange={handleSelectChange}
+          onBlur={commitImmediately}
+          value={currentSelectValue}
+          isClearable={!readonly}     // The component does not support readOnly, so we have to work around
+          isSearchable={!readonly}    // by setting other settings
+          openMenuOnClick={!readonly}
+          menuIsOpen={readonly ? false : undefined}
+          options={generateReactSelectLibrary(field)}
+          styles={selectFieldStyle(theme)}
+          name={field.name}
+          css={fieldTypeStyle(readonly)}>
+        </Select>
+      );
     }
 
-    // Find react-select equivalent for inital value
-    return library?.find(el => el.submitValue === input);
-  };
+  } else if (field.type === "date") {
+    return (
+      <ThemeProvider theme={calendarStyle(theme)}>
+        <input
+          onChange={handleTextChange}
+          onBlur={commitImmediately}
+          value={localValue}
+          readOnly={readonly}
+          type="datetime-local"
+          name={field.name}
+          // inputFormat="yyyy/MM/dd HH:mm"
+          css={[fieldTypeStyle(readonly), inputFieldTypeStyle(readonly),
+            {
+              resize: "none",
+            },
+          ]}
+          data-testid="dateTimePicker"
+        />
+      </ThemeProvider>
+    );
+  } else if (field.type === "time") {
+    return (
+      <ThemeProvider theme={calendarStyle(theme)}>
+        <input
+          onChange={handleTextChange}
+          onBlur={commitImmediately}
+          value={localValue}
+          readOnly={readonly}
+          type="time"
+          name={field.name}
+          // inputFormat="HH:mm"
+          css={[fieldTypeStyle(readonly), inputFieldTypeStyle(readonly),
+            {
+              resize: "none",
+            },
+          ]}
+        />
+      </ThemeProvider>
+    );
+  } else if (field.type === "text_long") {
+    return (
+      <textarea
+        onChange={handleTextChange}
+        onBlur={commitImmediately}
+        value={localValue}
+        readOnly={readonly}
+        name={field.name}
+        css={[fieldTypeStyle(readonly), inputFieldTypeStyle(readonly)]}
+      />
+    );
+  } else {
+    return (
+      <input
+        onChange={handleTextChange}
+        onBlur={commitImmediately}
+        value={localValue}
+        readOnly={readonly}
+        name={field.name}
+        css={[fieldTypeStyle(readonly), inputFieldTypeStyle(readonly)]}
+      />
+    );
+  }
+};
 
-  /**
-   * Returns a data structure to initialize the form fields with
-   * @param catalogs
-   */
-  const getInitialValues = (catalogs: Catalog[]) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const initValues: { [n: string]: any; } = {};
-
-    catalogs.forEach((catalog: Catalog, catalogIndex: number) => {
-      initValues["catalog" + catalogIndex] = {};
-      catalog.fields.forEach((field: MetadataField) => {
-        initValues["catalog" + catalogIndex][field.id] = field.value;
-
-        // Handle initial values for select fields differently
-        // Since react-select creates different values
-        if (field.collection) {
-          const library = generateReactSelectLibrary(field);
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          let searchValue: any = field.value;
-
-          if (Array.isArray(searchValue)) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const result: any[] = [];
-            helperHandleArrays(library, field.value, result);
-            searchValue = result;
-          } else {
-            searchValue = library?.find(el => el.submitValue === searchValue);
-          }
-
-          initValues["catalog" + catalogIndex][field.id] = searchValue;
-        }
-      });
-    });
-
-    return initValues;
-  };
-
-  /**
-   * Form Callbacks - Validation
-   */
+/**
+ * Check field values and render warning messages
+ */
+const FieldValidation: React.FC<{ field: MetadataField }> = ({ field }) => {
+  const { t } = useTranslation();
+  const theme = useTheme();
 
   /**
    * Validator for required fields
@@ -331,453 +508,36 @@ const Metadata: React.FC = () => {
     return t("metadata.validation.datetime");
   };
 
-  // // Function that combines multiple validation functions. Needs to be made typescript conform
-  // @ts-expect-error: This is copy-pasted from the non-typescript documentation of react-final-form
-  const composeValidators = (...validators) => value =>
-    validators.reduce((error, validator) => error || validator(value), undefined);
-
   /**
-   * Returns the desired combination of validators for a given field
+   * Returns messages in case something did not validate
    * @param field
    */
-  const getValidators = (field: MetadataField) => {
-    const validators = [];
+  const validate = (field: MetadataField) => {
+    const validations = [];
     if (field.required) {
-      validators.push(required);
+      validations.push(required(field.value));
     }
     if (field.id === "duration") {
-      validators.push(duration);
+      validations.push(duration(field.value));
     }
     if (field.type === "date" || field.type === "time") {
-      validators.push(dateTimeValidator);
+      validations.push(dateTimeValidator(field.value));
     }
 
-    return composeValidators(...validators);
+    return validations;
   };
 
-  /**
-   * Form Callbacks - Submitting
-   */
-
-  /**
-    * Sends a single value to the corresponding field in redux.
-    * This kinda breaks the form workflow, since we do not use the submit callback
-    * of the form class anymore.
-    * @param value value for the field
-    * @param fieldId String of the form "catalog{catalogIndex}.name"
-    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const submitSingleField = (value: any, fieldId: string) => {
-    const catalogIndexString = fieldId.substring(
-      fieldId.indexOf("g") + 1,
-      fieldId.indexOf("."),
-    );
-    const fieldName = fieldId.substring(
-      fieldId.indexOf(".") + 1,
-      fieldId.length,
-    );
-    const catalogIndex = parseInt(catalogIndexString);
-
-    // Find the corresponding field index in the redux catalog
-    for (let fieldIndex = 0; fieldIndex < catalogs[catalogIndex].fields.length; fieldIndex++) {
-      if (catalogs[catalogIndex].fields[fieldIndex].id === fieldName) {
-        // Update the field in the redux catalog
-        dispatch(setFieldValue({
-          catalogIndex: catalogIndex, fieldIndex: fieldIndex,
-          value: parseValue(catalogs[catalogIndex].fields[fieldIndex], value),
-        }));
-        break;
-      }
-    }
-  };
-
-  /**
-   * Executes given blur callback while also sending the value of the current field to redux
-   * @param e
-   * @param input
-   */
-  const blurWithSubmit = (
-    e: React.FocusEvent<HTMLInputElement, Element> | React.FocusEvent<HTMLTextAreaElement, Element>,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    input: any,
-  ) => {
-    input.onBlur(e);
-    submitSingleField(input.value, input.name);
-  };
-
-  /**
-   * Helper function for onSubmit
-   * Corrects formatting for certain form values
-   * @param field
-   * @param value
-   */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const parseValue = (field: MetadataField | null, value: any) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let returnValue: any = value;
-
-    // Parse values out react-multi-select and put them in an array
-    if (Array.isArray(value)) {
-      returnValue = [];
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      value.forEach((subValue: any) => {
-        returnValue.push(parseValue(null, subValue));  // Pass field as null to avoid each value into an array later on
-      });
-    }
-
-    // If the value is hidden an object due to react-select, extract it
-    if (typeof value === "object" && value !== null && Object.prototype.hasOwnProperty.call(value, "submitValue")) {
-      returnValue = value.submitValue;
-    } else if (typeof value === "object" && value !== null && value.__isNew__) {
-      returnValue = value.value;
-    }
-
-    // For these fields, the value needs to be inside an array
-    if (field && !Array.isArray(value) && (field.type === "mixed_text")) {
-      if (value) {
-        returnValue = [returnValue];
-      } else {
-        returnValue = [];
-      }
-    }
-
-    // For these fields, the value needs to be inside an array
-    if (field && (field.type === "date" || field.type === "time") &&
-      Object.prototype.toString.call(returnValue) === "[object Date]") {
-      // If invalid date
-      if ((isNaN(returnValue.getTime()))) {
-        // Do nothing
-      } else {
-        returnValue = returnValue.toJSON();
-      }
-    } else if (field && (field.type === "date" || field.type === "time") && typeof returnValue === "string") {
-      if (returnValue !== "") { // Empty string is allowed
-        returnValue = new Date(returnValue).toJSON();
-      }
-    }
-
-    return returnValue;
-  };
-
-  /**
-   * Callback for when the form is submitted
-   * Saves values in redux state
-   * @param values
-   */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const onSubmit = (values: { [x: string]: { [x: string]: any; }; }) => {
-    // For each submitted value, get the catalog it belongs to
-    Object.keys(values).forEach((formCatalogName: string) => {
-      const catalogIndex = parseInt(formCatalogName.replace("catalog", ""));
-
-      // For each field in the submitted values
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      Object.keys(values[formCatalogName]).forEach((formFieldName: any) => {
-        // Find the corresponding field index in the redux catalog
-        for (let fieldIndex = 0; fieldIndex < catalogs[catalogIndex].fields.length; fieldIndex++) {
-          if (catalogs[catalogIndex].fields[fieldIndex].id === formFieldName) {
-            // Update the field in the redux catalog
-            dispatch(setFieldValue({
-              catalogIndex: catalogIndex, fieldIndex: fieldIndex,
-              value: parseValue(catalogs[catalogIndex].fields[fieldIndex], values[formCatalogName][formFieldName]),
-            }));
-            break;
-          }
-        }
-      });
-
+  const validateStyle = (isError: boolean) => {
+    return css({
+      lineHeight: "32px",
+      marginLeft: "10px",
+      ...(isError && { color: `${theme.error}` }),
+      fontWeight: "bold",
     });
   };
 
-  /**
-   * Form - Rendering
-   */
-
-  /**
-   * Transforms field values and labels into an array of objects
-   * that can be parsed by react-select
-   * @param field
-   */
-  const generateReactSelectLibrary = (field: MetadataField) => {
-    if (field.collection) {
-      // For whatever reason react-select uses "value" as their key, which is not at all confusing
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const library: { value: any, label: string, submitValue: any; }[] = [];
-      Object.entries(field.collection).forEach(([key, value]) => {
-        // Parse Label
-        let descLabel = null;
-        if (i18n.exists(`metadata.${field.id}`)) {
-          descLabel = t(`metadata.${field.id}.${key.replaceAll(".", "-")}` as ParseKeys);
-
-          if (field.id === "license") {
-            descLabel = t(`metadata.${field.id}.${JSON.parse(key).label.replaceAll(".", "-")}` as ParseKeys);
-          }
-        }
-
-        // Change label for series
-        if (field.id === "isPartOf") {
-          descLabel = key;
-        }
-
-        // Add to library
-        library.push({
-          value: key,
-          label: descLabel ? descLabel : value,
-          submitValue: value,
-        });
-      });
-      library.sort((a, b) => a.label.localeCompare(b.label));
-      library.unshift({ value: "", label: "No value", submitValue: "" });
-      return library;
-    } else {
-      return null;
-    }
-  };
-
-  /**
-   * Generates different form components based on the field
-   * @param field
-   * @param input
-   */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const generateComponent = (field: MetadataField, input: any) => {
-    input.id = input.name;
-    if (field.collection) {
-      if (Array.isArray(field.value)) {
-        return (
-          <CreatableSelect {...input}
-            onBlur={e => { blurWithSubmit(e, input); }}
-            isMulti
-            isClearable={!field.readOnly}     // The component does not support readOnly, so we have to work around
-            isSearchable={!field.readOnly}    // by setting other settings
-            openMenuOnClick={!field.readOnly}
-            menuIsOpen={field.readOnly ? false : undefined}
-            options={generateReactSelectLibrary(field)}
-            styles={selectFieldStyle(theme)}
-            css={fieldTypeStyle(field.readOnly)}>
-          </CreatableSelect>
-        );
-      } else {
-        return (
-          <Select {...input}
-            onBlur={e => { blurWithSubmit(e, input); }}
-            isClearable={!field.readOnly}     // The component does not support readOnly, so we have to work around
-            isSearchable={!field.readOnly}    // by setting other settings
-            openMenuOnClick={!field.readOnly}
-            menuIsOpen={field.readOnly ? false : undefined}
-            options={generateReactSelectLibrary(field)}
-            styles={selectFieldStyle(theme)}
-            css={fieldTypeStyle(field.readOnly)}>
-          </Select>
-        );
-      }
-
-    } else if (field.type === "date") {
-      return (
-        <ThemeProvider theme={calendarStyle(theme)}>
-          <input {...input}
-            type="datetime-local"
-            name={field.id}
-            // inputFormat="yyyy/MM/dd HH:mm"
-            onBlur={e => { blurWithSubmit(e, input); }}
-            readOnly={field.readOnly}
-            css={[fieldTypeStyle(field.readOnly), inputFieldTypeStyle(field.readOnly),
-              {
-                resize: "none",
-              },
-            ]}
-            data-testid="dateTimePicker"
-          />
-        </ThemeProvider>
-      );
-    } else if (field.type === "time") {
-      return (
-        <ThemeProvider theme={calendarStyle(theme)}>
-          <input {...input}
-            type="time"
-            name={field.id}
-            // inputFormat="HH:mm"
-            onBlur={e => { blurWithSubmit(e, input); }}
-            readOnly={field.readOnly}
-            css={[fieldTypeStyle(field.readOnly), inputFieldTypeStyle(field.readOnly),
-              {
-                resize: "none",
-              },
-            ]}
-          />
-        </ThemeProvider>
-      );
-    } else if (field.type === "text_long") {
-      return (
-        <textarea {...input}
-          onBlur={e => { blurWithSubmit(e, input); }}
-          readOnly={field.readOnly}
-          css={[fieldTypeStyle(field.readOnly), inputFieldTypeStyle(field.readOnly)]}
-        />
-      );
-    } else {
-      return (
-        <input {...input}
-          onBlur={e => { blurWithSubmit(e, input); }}
-          readOnly={field.readOnly}
-          css={[fieldTypeStyle(field.readOnly), inputFieldTypeStyle(field.readOnly)]}
-        />
-      );
-    }
-  };
-
-  /**
-   * Renders a field in a catalog
-   * @param field
-   * @param catalogIndex
-   * @param fieldIndex
-   */
-  const renderField = (field: MetadataField, catalogIndex: number, fieldIndex: number) => {
-
-    /**
-     * Wrapper function for component generation.
-     * Handles the special case of DateTimePicker/TimePicker, which
-     * can"t handle empty string as a value (which is what Opencast uses to
-     * represent no date/time)
-     */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const generateComponentWithModifiedInput = (field: MetadataField, input: FieldInputProps<any, HTMLElement>) => {
-      if ((field.type === "date" || field.type === "time") && input.value === "") {
-        const { value, ...other } = input;
-        return generateComponent(field, other);
-      }
-      // <input type="datetime-local"> is picky about its value and won"t accept
-      // global datetime strings, so we have to convert them to local ourselves.
-      // TODO: Also we really should not be modifying the input element like that
-      // so ideally the conversion happens somewhere else in the code
-      // (see error in the console for further details)
-      if ((field.type === "date" || field.type === "time")) {
-        input = cloneDeep(input);
-        const leDate = new Date(input.value);
-        leDate.setMinutes(leDate.getMinutes() - leDate.getTimezoneOffset());
-        input.value = leDate.toISOString().slice(0, 16);
-        return generateComponent(field, input);
-      } else {
-        return generateComponent(field, input);
-      }
-    };
-
-    return (
-      <Field key={fieldIndex}
-        name={"catalog" + catalogIndex + "." + field.id}
-        validate={getValidators(field)}
-        // react-final-form complains if we don"t specify checkboxes here
-        type={field.type === "boolean" ? "checkbox" : undefined}
-      >
-        {({ input, meta }) => (
-          <div css={fieldStyle} data-testid={field.id}>
-            <label css={fieldLabelStyle} htmlFor={input.name}>
-              <>{
-                i18n.exists(`metadata.labels.${field.id}`) ?
-                  t(`metadata.labels.${field.id}` as ParseKeys) : field.id
-              }</>
-              {field.required &&
-                <span css={fieldLabelRequiredStyle}>
-                  {t("metadata.required")}
-                </span>
-              }
-            </label>
-
-            {generateComponentWithModifiedInput(field, input)}
-            {meta.error && <span css={validateStyle(true)}>{meta.error}</span>}
-          </div>
-        )}
-      </Field>
-    );
-  };
-
-  const renderCatalog = (
-    catalog: Catalog,
-    catalogIndex: number,
-    configureFields: { [key: string]: configureFieldsAttributes; },
-  ) => {
-
-
-    return (
-      <div key={catalogIndex} css={catalogStyle}>
-        <div css={[titleStyle(theme), titleStyleBold(theme)]}>
-          {i18n.exists(`metadata.${catalog.title.replaceAll(".", "-")}`) ?
-            t(`metadata.${catalog.title.replaceAll(".", "-")}` as ParseKeys) : catalog.title
-          }
-        </div>
-
-        {catalog.fields.map((field, i) => {
-          // Render fields based on given array (usually parsed from config settings)
-          if (field.id in configureFields && "show" in configureFields[field.id]) {
-            if (configureFields[field.id].show) {
-              return renderField(field, catalogIndex, i);
-            } else {
-              return undefined;
-            }
-          }
-          return renderField(field, catalogIndex, i);
-        })}
-
-      </div>
-    );
-  };
-
-  /**
-   * Main render function. Renders all catalogs in a single form
-   */
-  const render = () => {
-    return (
-      <Form
-        onSubmit={onSubmit}
-        subscription={{ submitting: true, pristine: true }} // Hopefully causes less rerenders
-        initialValues={getInitialValues(catalogs)}
-        render={({ handleSubmit, form }) => (
-          <form onSubmit={event => {
-            handleSubmit(event);
-            // Ugly fix for form not getting updated after submit. TODO: Find a better fix
-            form.reset();
-          }} css={metadataStyle}>
-
-            {getStatus === "failed" &&
-              <ErrorBox>
-                <span css={{ whiteSpace: "pre-line" }}>
-                  {"A problem occurred during communication with Opencast. \n"}
-                  {getError ?
-                    t("various.error-details-text", { errorMessage: getError }) : undefined
-                  }
-                </span>
-              </ErrorBox>
-            }
-
-            {catalogs.map((catalog, i) => {
-              if (settings.metadata.configureFields) {
-                if (catalog.title in settings.metadata.configureFields) {
-                  // If there are no fields for a given catalog, do not render
-                  if (Object.keys(settings.metadata.configureFields[catalog.title]).length > 0) {
-                    return renderCatalog(catalog, i, settings.metadata.configureFields[catalog.title]);
-                  } else {
-                    return undefined;
-                  }
-                }
-              }
-              // If there are no settings for a given catalog, just render it completely
-              return renderCatalog(catalog, i, {});
-            })}
-
-            {/* For debugging the forms current values*/}
-            {/* <FormSpy subscription={{ values: true }}>
-                {({ values }) => (
-                  <pre>{JSON.stringify(values, null, 2)}</pre>
-                )}
-              </FormSpy> */}
-          </form>
-        )}
-      />
-    );
-  };
-
   return (
-    render()
+    <span css={validateStyle(true)}>{validate(field)}</span>
   );
 };
 

--- a/src/main/Save.tsx
+++ b/src/main/Save.tsx
@@ -25,7 +25,6 @@ import { useTranslation } from "react-i18next";
 import {
   setHasChanges as metadataSetHasChanges,
   selectHasChanges as metadataSelectHasChanges,
-  selectCatalogs,
 } from "../redux/metadataSlice";
 import {
   selectSubtitles, selectHasChanges as selectSubtitleHasChanges,
@@ -125,7 +124,6 @@ export const SaveButton: React.FC<{
   const tracks = useAppSelector(selectTracks);
   const customizedTrackSelection = useAppSelector(selectCustomizedTrackSelection);
   const subtitles = useAppSelector(selectSubtitles);
-  const metadata = useAppSelector(selectCatalogs);
   const selectedWorkflowId = useAppSelector(selectSelectedWorkflowId);
   const workflowStatus = useAppSelector(selectStatus);
   const theme = useTheme();
@@ -166,7 +164,6 @@ export const SaveButton: React.FC<{
       tracks: tracks,
       customizedTrackSelection,
       subtitles: prepareSubtitles(),
-      metadata: metadata,
       workflow: selectedWorkflowId ? [{ id: selectedWorkflowId }] : undefined,
     }));
   };

--- a/src/main/SubtitleVideoArea.tsx
+++ b/src/main/SubtitleVideoArea.tsx
@@ -213,6 +213,7 @@ const VideoSelectDropdown: React.FC<{
       <Select
         name={dropdownName}
         styles={selectFieldStyle(theme)}
+        isMulti={false}
         css={subtitleAddFormStyle}
         options={data}
         defaultValue={data.filter(({ value }) => value === stringifyFlavor(defaultFlavor))}

--- a/src/redux/metadataSlice.ts
+++ b/src/redux/metadataSlice.ts
@@ -1,21 +1,33 @@
-import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { createEntityAdapter, createSlice, EntityState, nanoid, PayloadAction } from "@reduxjs/toolkit";
 import { client } from "../util/client";
 
 import { httpRequestState } from "../types";
 import { settings } from "../config";
 import { createAppAsyncThunk } from "./createAsyncThunkWithTypes";
+import { RootState } from "./store";
 
 export interface Catalog {
+  id: string      // generated
+  fieldIds: string[];      // references into `fields` adapter
+
+  flavor: string, // "dublincore/episode"
+  title: string,  // name identifier
+}
+
+interface BackendCatalog {
   fields: MetadataField[],
   flavor: string, // "dublincore/episode"
   title: string,  // name identifier
 }
 
 export interface MetadataField {
+  id: string;              // `${catalogId}:${fieldName}`
+  catalogId: string;
+  name: string;            // original `id`
+
   readOnly: boolean,
-  id: string;      // name
-  label: string;   // name identifier
-  type: string;    // irrelevant?
+  label: string;
+  type: string;
   value: string,
   required: boolean,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -23,15 +35,18 @@ export interface MetadataField {
 }
 
 interface metadata {
-  catalogs: Catalog[];
+  catalogs: EntityState<Catalog, string>,
+  fields: EntityState<MetadataField, string>,
   hasChanges: boolean;         // Did user make changes to metadata view since last save
 }
 
-// TODO: Create an "httpRequestState" array or something
-const initialState: metadata & httpRequestState = {
-  catalogs: [],
-  hasChanges: false,
+const catalogsAdapter = createEntityAdapter<Catalog>();
+const fieldsAdapter = createEntityAdapter<MetadataField>();
 
+const initialState: metadata & httpRequestState = {
+  catalogs: catalogsAdapter.getInitialState(),
+  fields: fieldsAdapter.getInitialState(),
+  hasChanges: false,
   status: "idle",
   error: undefined,
   errorReason: "unknown",
@@ -43,7 +58,7 @@ export const fetchMetadata = createAppAsyncThunk("metadata/fetchMetadata", async
   }
 
   const response = await client.get(`${settings.opencast.url}/editor/${settings.id}/metadata.json`);
-  return JSON.parse(response);
+  return JSON.parse(response) as BackendCatalog[];
 });
 
 /**
@@ -53,12 +68,12 @@ const metadataSlice = createSlice({
   name: "metadataState",
   initialState,
   reducers: {
-    setFieldValue: (state, action: PayloadAction<{ catalogIndex: number, fieldIndex: number, value: string; }>) => {
-      state.catalogs[action.payload.catalogIndex].fields[action.payload.fieldIndex].value = action.payload.value;
+    setFieldValue: (state, action: PayloadAction<{ id: string; value: string }>) => {
+      fieldsAdapter.updateOne(state.fields, {
+        id: action.payload.id,
+        changes: { value: action.payload.value },
+      });
       state.hasChanges = true;
-    },
-    setFieldReadonly: (state, action: PayloadAction<{ catalogIndex: number, fieldIndex: number, value: boolean; }>) => {
-      state.catalogs[action.payload.catalogIndex].fields[action.payload.fieldIndex].readOnly = action.payload.value;
     },
     setHasChanges: (state, action: PayloadAction<metadata["hasChanges"]>) => {
       state.hasChanges = action.payload;
@@ -69,12 +84,39 @@ const metadataSlice = createSlice({
       fetchMetadata.pending, (state, _action) => {
         state.status = "loading";
       });
-    builder.addCase(
-      fetchMetadata.fulfilled, (state, action) => {
-        state.catalogs = action.payload;
+    builder.addCase(fetchMetadata.fulfilled, (state, action) => {
+      // Entity Adapter preparations
+      const catalogEntities: Catalog[] = [];
+      const fieldEntities: MetadataField[] = [];
 
-        state.status = "success";
+      action.payload.forEach(rawCatalog => {
+        const catalogId = nanoid();                // new stable id
+        const fieldIds: string[] = [];
+
+        rawCatalog.fields.forEach(field => {
+          const fieldId = `${catalogId}:${field.id}`; // unique per catalog
+          fieldIds.push(fieldId);
+
+          fieldEntities.push({
+            ...field,
+            id: fieldId,
+            name: field.id,
+            catalogId,         // back‑reference for convenience
+          });
+        });
+
+        catalogEntities.push({
+          ...rawCatalog,
+          id: catalogId,
+          fieldIds,
+        });
       });
+
+      // Replace state with the fetched entities
+      catalogsAdapter.setAll(state.catalogs, catalogEntities);
+      fieldsAdapter.setAll(state.fields, fieldEntities);
+      state.hasChanges = false;
+    });
     builder.addCase(
       fetchMetadata.rejected, (state, action) => {
         state.status = "failed";
@@ -82,15 +124,18 @@ const metadataSlice = createSlice({
       });
   },
   selectors: {
-    selectCatalogs: state => state.catalogs,
     selectHasChanges: state => state.hasChanges,
     selectGetStatus: state => state.status,
     selectGetError: state => state.error,
     selectTitleFromEpisodeDc: state => {
-      for (const catalog of state.catalogs) {
+      for (const catalogId of state.catalogs.ids) {
+        const catalog = state.catalogs.entities[catalogId];
+        if (!catalog) { continue; }
+
         if (catalog.flavor === "dublincore/episode") {
-          for (const field of catalog.fields) {
-            if (field.id === "title") {
+          for (const fieldId of state.fields.ids) {
+            const field = state.fields.entities[fieldId];
+            if (field.catalogId === catalogId && field.name === "title") {
               return field.value;
             }
           }
@@ -102,10 +147,18 @@ const metadataSlice = createSlice({
   },
 });
 
-export const { setFieldValue, setHasChanges, setFieldReadonly } = metadataSlice.actions;
+export const { setFieldValue, setHasChanges } = metadataSlice.actions;
 
 export const {
-  selectCatalogs,
+  selectIds: selectCatalogIds,
+  selectById: selectCatalogById,
+} = catalogsAdapter.getSelectors<RootState>(s => s.metadataState.catalogs);
+
+export const {
+  selectById: selectFieldById,
+} = fieldsAdapter.getSelectors<RootState>(s => s.metadataState.fields);
+
+export const {
   selectHasChanges,
   selectGetStatus,
   selectGetError,

--- a/src/redux/workflowPostSlice.ts
+++ b/src/redux/workflowPostSlice.ts
@@ -3,6 +3,7 @@ import { client } from "../util/client";
 import { Segment, PostEditArgument, httpRequestState } from "../types";
 import { settings } from "../config";
 import { createAppAsyncThunk } from "./createAsyncThunkWithTypes";
+import { selectCatalogById, selectCatalogIds, selectFieldById } from "./metadataSlice";
 
 const initialState: httpRequestState = {
   status: "idle",
@@ -11,10 +12,32 @@ const initialState: httpRequestState = {
 };
 
 export const postVideoInformation =
-  createAppAsyncThunk("video/postVideoInformation", async (argument: PostEditArgument) => {
+  createAppAsyncThunk("video/postVideoInformation", async (argument: PostEditArgument, { getState }) => {
     if (!settings.id) {
       throw new Error("Missing media package id");
     }
+
+    // Transform
+    const state = getState();
+    const catalogsJson = selectCatalogIds(state).map(catId => {
+      const cat = selectCatalogById(state, catId);
+
+      const fieldsJson = cat.fieldIds.map(fieldId => {
+        const field = selectFieldById(state, fieldId);
+
+        // Remove internal keys (`id`, `catalogId`) & restore original field `id`
+        const { catalogId, id: compositeId, ...rest } = field;
+        const originalId = compositeId.split(":")[1];          // after `${catalogId}:`
+
+        return { ...rest, id: originalId, collection: undefined };
+      });
+
+      return {
+        flavor: cat.flavor,
+        title: cat.title,
+        fields: fieldsJson,
+      };
+    });
 
     const response = await client.post(`${settings.opencast.url}/editor/${settings.id}/edit.json`,
       {
@@ -23,7 +46,7 @@ export const postVideoInformation =
         customizedTrackSelection: argument.customizedTrackSelection,
         subtitles: argument.subtitles,
         workflows: argument.workflow,
-        metadataJSON: JSON.stringify(argument.metadata),
+        metadataJSON: JSON.stringify(catalogsJson),
       },
     );
     return response;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,3 @@
-import { Catalog } from "./redux/metadataSlice";
-
 export interface Segment {
   id: string,
   start: number,
@@ -73,7 +71,6 @@ export interface PostEditArgument {
   customizedTrackSelection: boolean
   subtitles: SubtitlesFromOpencast[]
   workflow?: [{id: string}]
-  metadata: Catalog[]
 }
 
 // Use respective i18n keys as values

--- a/tests/metadata.test.ts
+++ b/tests/metadata.test.ts
@@ -11,13 +11,13 @@ test.describe('Test Metadata-Page', () => {
   test('Check Inputfields', async ({ page }) => {
 
     for (let i = 0; i < input.length; i++) {
-      const locator = page.locator('input[name="catalog0.' + input[i] + '"]');
+      const locator = page.locator('input[name="' + input[i] + '"]');
       await expect(locator).toHaveValue(iValue[i]);
-      await page.click('input[name="catalog0.' + input[i] + '"]');
-      await page.fill('input[name="catalog0.' + input[i] + '"]', iFill[i]);
+      await page.click('input[name="' + input[i] + '"]');
+      await page.fill('input[name="' + input[i] + '"]', iFill[i]);
     }
     for (let i = 0; i < dropdown.length; i++) {
-      const locator = page.locator('input[name="catalog0.' + dropdown[i] + '"]');
+      const locator = page.locator('input[name="' + dropdown[i] + '"]');
       await expect(locator).toHaveValue(dValue[i]);
     }
   });
@@ -25,10 +25,10 @@ test.describe('Test Metadata-Page', () => {
   test('Check other fields', async ({ page }) => {
 
     // different syntax and or not editable
-    const description = page.locator('textarea[name="catalog0.description"]');
+    const description = page.locator('textarea[name="description"]');
     await expect(description).toHaveValue('');
-    await page.click('textarea[name="catalog0.description"]');
-    await page.fill('textarea[name="catalog0.description"]', 'Test-Description');
+    await page.click('textarea[name="description"]');
+    await page.fill('textarea[name="description"]', 'Test-Description');
 
     const startDate = page.locator('input[name="startDate"]');
     await expect(startDate).toHaveValue(/[0-9]/);
@@ -36,10 +36,10 @@ test.describe('Test Metadata-Page', () => {
     const created = page.locator('input[name="created"]');
     await expect(created).toHaveValue(/[0-9]/);
 
-    const publisher = page.locator('input[name="catalog0.publisher"]');
+    const publisher = page.locator('input[name="publisher"]');
     await expect(publisher).toHaveValue('');
 
-    const identifier = page.locator('input[name="catalog0.identifier"]');
+    const identifier = page.locator('input[name="identifier"]');
     await expect(identifier).toHaveValue('ID-dual-stream-demo');
 
   });
@@ -47,24 +47,24 @@ test.describe('Test Metadata-Page', () => {
   test('Check: Change Dropdown Value', async ({ page, browserName }) => {
 
     // Language
-    await page.click('text=LanguageNo value >> :nth-match(svg, 2)');
+    await page.click('[data-testid="language"] [class*="-control"]');
     await page.click('div[id*="option-22"]');
 
     // License
-    await page.click('text=LicenseCC-BY-SA >> :nth-match(svg, 2)');
+    await page.click('[data-testid="license"] [class*="-control"]');
     await page.click('div[id*="option-8"]');
 
     // Series / isPartOf
-    await page.click('text=SeriesNo value >> :nth-match(svg, 2)');
+    await page.click('[data-testid="isPartOf"] [class*="-control"]');
     await page.click('div[id*="option-4"]');
 
     // Creator
-    await page.click('[id="catalog0.creator"] div div >> :nth-match(div, 4)');
+    await page.click('[data-testid="creator"] [class*="-control"]');
     await page.click('div[id*="option-15"]');
     await page.click('[aria-label="Remove Lars Kiesow"]');
 
     // Contributor
-    await page.click('text=Contributor(s)Select... >> svg');
+    await page.click('[data-testid="contributor"] [class*="-control"]');
     await page.click('div[id*="option-15"]');
   });
 
@@ -75,5 +75,5 @@ const iValue = ['Dual-Stream Demo', '', '', '00:01:04', '', ''];
 const iFill = ['Test-Title', 'Test-Subject', 'Test-Rights', '00:02:45', 'Test-Location', 'Test-Source'];
 
 const dropdown = ['language', 'license', 'isPartOf', 'creator', 'contributor'];
-const dValue = ['', '{"label":"EVENTS.LICENSE.CCBYSA", "order":3, "selectable": true}', '', 'Lars Kiesow', ''];
+const dValue = ['', 'CC-BY-SA', '', 'Lars Kiesow', ''];
 


### PR DESCRIPTION
This patch rewrites the Metadata component. This accomplishes:
- Stop the whole Metadata component from rerendering each time redux state is updated. This was causing ui elements to become unresponsive in certain cases (e.g. having tens of thousands of series in your Opencast).
- Makes the code in the Metadata component far less difficult to read..

### How to test this

Can be tested as usual. Make sure that editing and saving Metadata still works as expected.