### PR TITLE
Fix GHA workflow issues

### DIFF
--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   detect:
+    needs: member
     if: ${{ needs.member.outputs.is_team_member == 'true'
       || github.event.pull_request.head.repo.full_name == 'opencast/opencast-editor' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
I noticed that https://github.com/opencast/opencast-editor/pull/1608 did not have a deployed test instance.  It's unclear the relevant GHA jobs are being skipped, but this issue is to dianose and then hopefully fix that.
