### PR TITLE
Show error if no video tracks present

### DIFF
--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -55,6 +55,7 @@
       "comError-text": "A problem occurred during communication with Opencast.",
       "loadError-text": "An error has occurred loading this video.",
       "durationError-text": "Opencast failed to provide the video duration.",
+      "noVideoError-text": "The editor does not support audio files yet!",
       "title-tooltip": "Video Title",
       "presenter-tooltip": "Video Presenters"
     },

--- a/src/main/Cutting.tsx
+++ b/src/main/Cutting.tsx
@@ -18,6 +18,7 @@ import {
   setIsPlayPreview,
   jumpToPreviousSegment,
   jumpToNextSegment,
+  selectVideos,
 } from "../redux/videoSlice";
 import { useTranslation } from "react-i18next";
 import { useAppDispatch, useAppSelector } from "../redux/store";
@@ -41,6 +42,7 @@ const Cutting: React.FC = () => {
     state.videoState.status);
   const error = useAppSelector((state: { videoState: { error: httpRequestState["error"]; }; }) =>
     state.videoState.error);
+  const videos = useAppSelector(selectVideos);
   const duration = useAppSelector(selectDuration);
   const theme = useTheme();
   const errorReason = useAppSelector((state: { videoState: { errorReason: httpRequestState["errorReason"]; }; }) =>
@@ -66,6 +68,14 @@ const Cutting: React.FC = () => {
         }));
       }
     } else if (videoURLStatus === "success") {
+      // Editor can not handle events with no videos/audio-only atm
+      if (videos === null || videos.length === 0) {
+        dispatch(setError({
+          error: true,
+          errorMessage: t("video.noVideoError-text"),
+          errorDetails: error,
+        }));
+      }
       if (duration === null) {
         dispatch(setError({
           error: true,
@@ -74,7 +84,7 @@ const Cutting: React.FC = () => {
         }));
       }
     }
-  }, [videoURLStatus, dispatch, error, t, errorReason, duration]);
+  }, [videoURLStatus, dispatch, error, t, errorReason, duration, videos]);
 
   // Style
   const cuttingStyle = css({


### PR DESCRIPTION
Related to https://github.com/opencast/opencast-editor/issues/1636#issuecomment-3332533506.

As of Opencast 18, Opencast officially supports events with audio-only files, meaning events are not guaranteed to have at least one track with video anymore. The latter is however an implicit assumption in our app and it will not work for audio only events. Until we fix this, we should at least display an error message to users instead of letting them stumble around in a half broken application.

<img width="1195" height="791" alt="Bildschirmfoto vom 2025-09-25 09-09-11" src="https://github.com/user-attachments/assets/b36d7a51-1111-4758-8ddb-9efe97d4e99d" />
