### PR TITLE
Fix test server selection logic

### DIFF
--- a/.github/workflows/deploy-main-branches.yml
+++ b/.github/workflows/deploy-main-branches.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Determine the correct test server
         id: test-server
-        run: echo "server=https://`./.github/get-release-server.sh ${{ github.ref_name }}`" >> $GITHUB_OUTPUT
+        run: echo "server=`./.github/get-release-server.sh ${{ github.ref_name }}`" >> $GITHUB_OUTPUT
 
       - name: Determine branch name
         id: branch-name

--- a/.github/workflows/pr-deploy-test-branch.yml
+++ b/.github/workflows/pr-deploy-test-branch.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Determine the correct test server
         id: test-server
-        run: echo "server=https://`./.github/get-release-server.sh ${{ github.ref_name }}`" >> $GITHUB_OUTPUT
+        run: echo "server=`./.github/get-release-server.sh ${{ github.ref_name }}`" >> $GITHUB_OUTPUT
 
       - name: Determine branch name
         id: branch-name


### PR DESCRIPTION
This PR fixes #1656 (also noted in #1654), where the test server selection logic was incorrect.  We're using the same script in the admin and editor modules, but admin requires the schema whereas editor does *not*.
