### PR TITLE
Remove extra dashes from license designators

### DIFF
--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -185,13 +185,13 @@
       },
       "license": {
         "EVENTS-LICENSE-CC0": "CC0",
-        "EVENTS-LICENSE-CCBYND": "CC-BY-ND",
-        "EVENTS-LICENSE-CCBYNCND": "CC-BY-NC-ND",
-        "EVENTS-LICENSE-CCBYNCSA": "CC-BY-NC-SA",
+        "EVENTS-LICENSE-CCBYND": "CC BY-ND",
+        "EVENTS-LICENSE-CCBYNCND": "CC BY-NC-ND",
+        "EVENTS-LICENSE-CCBYNCSA": "CC BY-NC-SA",
         "EVENTS-LICENSE-ALLRIGHTS": "All rights reserved",
-        "EVENTS-LICENSE-CCBYSA": "CC-BY-SA",
-        "EVENTS-LICENSE-CCBYNC": "CC-BY-NC",
-        "EVENTS-LICENSE-CCBY": "CC-BY"
+        "EVENTS-LICENSE-CCBYSA": "CC BY-SA",
+        "EVENTS-LICENSE-CCBYNC": "CC BY-NC",
+        "EVENTS-LICENSE-CCBY": "CC BY"
       },
       "calendar-prev": "Previous",
       "calendar-next": "Next"


### PR DESCRIPTION
All designators used an unnecessary dash after the "CC" part, like "CC-BY", which is supposed to be "CC BY".
Replacing the dashes with a space also aligns these designators with the default ones in the Admin UI.