### PR TITLE
Help with Subtitle Editor responsiveness

### DIFF
--- a/src/cssStyles.tsx
+++ b/src/cssStyles.tsx
@@ -426,3 +426,9 @@ export const undisplay = (maxWidth: number) => css({
     display: "none",
   },
 });
+
+export const undisplayContainer = (maxWidth: number) => css({
+  [`@container (max-width: ${maxWidth}px)`]: {
+    display: "none",
+  },
+});

--- a/src/main/SubtitleEditor.tsx
+++ b/src/main/SubtitleEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { css } from "@emotion/react";
-import { basicButtonStyle } from "../cssStyles";
+import { basicButtonStyle, undisplay } from "../cssStyles";
 import { LuChevronLeft, LuDownload, LuTrash2, LuUpload } from "react-icons/lu";
 import {
   selectSubtitlesFromOpencastById,
@@ -47,6 +47,8 @@ import { ThemedTooltip } from "./Tooltip";
 import { titleStyle, titleStyleBold } from "../cssStyles";
 import { generateButtonTitle } from "./SubtitleSelect";
 import { ConfirmationModal, ConfirmationModalHandle, Modal, ModalHandle, ProtoButton } from "@opencast/appkit";
+
+const topRightButtonsBreakpoint = 1100;
 
 /**
  * Displays an editor view for a selected subtitle file
@@ -131,6 +133,7 @@ const SubtitleEditor: React.FC = () => {
     display: "flex",
     flexDirection: "row",
     gap: "10px",
+    flexWrap: "wrap",
   });
 
   const subAreaStyle = css({
@@ -246,7 +249,7 @@ const DeleteButton: React.FC = () => {
           css={[basicButtonStyle(theme), subtitleButtonStyle(theme)]}
         >
           <LuTrash2 css={{ fontSize: "16px" }}/>
-          <span>{t("subtitles.deleteButton-title")}</span>
+          <span css={undisplay(topRightButtonsBreakpoint)}>{t("subtitles.deleteButton-title")}</span>
         </ProtoButton>
       </ThemedTooltip>
       {/* Hidden input field for upload */}
@@ -297,7 +300,7 @@ const DownloadButton: React.FC = () => {
         css={[basicButtonStyle(theme), subtitleButtonStyle(theme)]}
       >
         <LuDownload css={{ fontSize: "16px" }} />
-        <span>{t("subtitles.downloadButton-title")}</span>
+        <span css={undisplay(topRightButtonsBreakpoint)}>{t("subtitles.downloadButton-title")}</span>
       </ProtoButton>
     </ThemedTooltip>
   );
@@ -373,7 +376,7 @@ const UploadButton: React.FC<{
           css={[basicButtonStyle(theme), subtitleButtonStyle(theme)]}
         >
           <LuUpload css={{ fontSize: "16px" }}/>
-          <span>{t("subtitles.uploadButton-title")}</span>
+          <span css={undisplay(topRightButtonsBreakpoint)}>{t("subtitles.uploadButton-title")}</span>
         </ProtoButton>
       </ThemedTooltip>
       {/* Hidden input field for upload */}

--- a/src/main/VideoControls.tsx
+++ b/src/main/VideoControls.tsx
@@ -11,7 +11,7 @@ import {
 } from "../redux/videoSlice";
 
 import { convertMsToReadableString } from "../util/utilityFunctions";
-import { BREAKPOINTS, basicButtonStyle, undisplay } from "../cssStyles";
+import { BREAKPOINTS, basicButtonStyle, undisplayContainer } from "../cssStyles";
 
 import { KEYMAP, rewriteKeys } from "../globalKeys";
 import { useTranslation } from "react-i18next";
@@ -69,6 +69,7 @@ const VideoControls: React.FC<{
     paddingTop: "10px",
     paddingBottom: "10px",
     gap: "30px",
+    containerType: "inline-size", // So @container-queries can be used
   });
 
   return (
@@ -178,7 +179,7 @@ const PreviewMode: React.FC<{
           }
         }}
       >
-        <div css={[previewModeTextStyle(theme), undisplay(BREAKPOINTS.medium)]}>
+        <div css={[previewModeTextStyle(theme), undisplayContainer(BREAKPOINTS.medium)]}>
           {t("video.previewButton")}
         </div>
         {isPlayPreview ? <FaToggleOn css={[basicButtonStyle(theme), switchIconStyle]} />
@@ -342,22 +343,28 @@ const TimeDisplay: React.FC<{
   const duration = useAppSelector(selectDuration);
   const theme = useTheme();
 
+  const timeDisplayStyle = css({
+    display: "flex",
+    flexDirection: "row",
+    gap: "5px",
+  });
+
   const timeTextStyle = (theme: Theme) => css({
     display: "inline-block",
     color: `${theme.text}`,
   });
 
   return (
-    <div css={{ display: "flex", flexDirection: "row", gap: "5px" }}>
+    <div css={timeDisplayStyle}>
       <ThemedTooltip title={t("video.current-time-tooltip")}>
         <time css={timeTextStyle(theme)}
           tabIndex={0} role="timer" aria-label={t("video.time-aria") + ": " + convertMsToReadableString(currentlyAt)}>
           {new Date((currentlyAt ? currentlyAt : 0)).toISOString().substr(11, 10)}
         </time>
       </ThemedTooltip>
-      <div css={undisplay(BREAKPOINTS.medium)}>{" / "}</div>
+      <div css={undisplayContainer(BREAKPOINTS.medium)}>{" / "}</div>
       <ThemedTooltip title={t("video.time-duration-tooltip")}>
-        <div css={[timeTextStyle(theme), undisplay(BREAKPOINTS.medium)]}
+        <div css={[timeTextStyle(theme), undisplayContainer(BREAKPOINTS.medium)]}
           tabIndex={0} aria-label={t("video.duration-aria") + ": " + convertMsToReadableString(duration)}>
           {new Date((duration ? duration : 0)).toISOString().substr(11, 10)}
         </div>
@@ -459,7 +466,7 @@ const VolumeSlider: React.FC<{
       </ThemedTooltip>
       <ThemedTooltip title={t("video.volume-tooltip", { current: Math.trunc(volume * 100) })}>
         <Slider
-          css={sliderStyle}
+          css={[sliderStyle, undisplayContainer(BREAKPOINTS.medium)]}
           min={0}
           max={1}
           step={0.01}


### PR DESCRIPTION
Follow up on #1160. Fixes the rest of #1391 and #928.

Should help with the video controls and the buttons on the top right overflowing out of sight for smaller window widths in the subtitle editor view. They will eventually still disappear if the width gets small enough, but  the subtitle editor is arguably not designed to work for such small widths anyway.

<img width="1138" height="1018" alt="Bildschirmfoto vom 2026-01-28 12-38-30" src="https://github.com/user-attachments/assets/08ff4f95-9cbb-4a85-bedc-812bb4ae1174" />

### How to test this

Open the subtitle editor (and every other view that has video controls) and test out different screen sizes. (Views can be enabled in the config or via query parameter, e.g. `subtitles.show=true`)