### PR TITLE
Disable deleting entries from readonly creatable selects

### DIFF
--- a/src/main/Metadata.tsx
+++ b/src/main/Metadata.tsx
@@ -390,7 +390,10 @@ const FieldContent: React.FC<{ field: MetadataField, readonly?: boolean }> = ({ 
           options={field.collection ? generateReactSelectLibrary(field) : []}
           styles={selectFieldStyle(theme)}
           name={field.name}
-          css={fieldTypeStyle(readonly)}>
+          css={fieldTypeStyle(readonly)}
+          components={readonly ? {
+            MultiValueRemove: () => null,
+          } : undefined}>
         </CreatableSelect>
       );
     } else {


### PR DESCRIPTION
Fixes #641. 


Admins can configure metadata fields as "read only". Users should not be able to change those fields. Unfortunately, they were able to delete entries from creatable selects (contributors, presenters) even if they should have been read-only. This fixes that by removing the delete button for creatable selects.

### How to test this

In order to test this, you have to able to change the editor configuration. You could change it like in #641 for example.