### PR TITLE
Allow translating preview mode status in tooltip

### DIFF
--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -45,7 +45,8 @@
 
     "video": {
       "previewButton": "Preview Mode",
-      "previewButton-tooltip": "Skips deleted segments when playing the video. Currently {{status}}. Hotkey: {{hotkeyName}}",
+      "previewButton-tooltip-on": "Skips deleted segments when playing the video. Currently on. Hotkey: {{hotkeyName}}",
+      "previewButton-tooltip-off": "Skips deleted segments when playing the video. Currently off. Hotkey: {{hotkeyName}}",
       "previewButton-aria": "Enable or disable preview mode. Hotkey: {{hotkeyName}}.",
       "playButton-tooltip": "Play video",
       "pauseButton-tooltip": "Pause video",

--- a/src/main/VideoControls.tsx
+++ b/src/main/VideoControls.tsx
@@ -162,8 +162,7 @@ const PreviewMode: React.FC<{
 
   return (
     <ThemedTooltip
-      title={t("video.previewButton-tooltip", {
-        status: (isPlayPreview ? "on" : "off"),
+      title={t(isPlayPreview ? "video.previewButton-tooltip-on" : "video.previewButton-tooltip-off", {
         hotkeyName: rewriteKeys(KEYMAP.videoPlayer.preview.key),
       })}
     >


### PR DESCRIPTION
Helps with #929.

The hover tooltip for the preview mode button also lists the current state. This was always either "on" or "off" which could not be translated. With this patch it can be translated.

There are now two seperate strings for the two states. This is to ensure that translators can translate as they see fit.