### PR TITLE
Rename "Shortcuts" to "Hotkeys"

### DIFF
--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -332,7 +332,7 @@
     },
 
     "keyboardControls": {
-      "header": "Shortcuts",
+      "header": "Hotkeys",
       "defaultGroupName": "General",
       "missingLabel": "Unknown",
       "groupVideoPlayer": "Video Player",

--- a/src/main/MainContent.tsx
+++ b/src/main/MainContent.tsx
@@ -90,7 +90,7 @@ const MainContent: React.FC = () => {
     padding: "20px",
   });
 
-  // Apply main focus to the current view for keyboard shortcuts.
+  // Apply main focus to the current view for keyboard hotkeys.
   const mainRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     // Auto-focus main content when route changes


### PR DESCRIPTION
Helps with https://github.com/opencast/opencast-editor/issues/929.

We are calling them hotkeys everywhere else.
Let's get this consistent.