### PR TITLE
Add padding to subtitle editor bottom

### DIFF
--- a/src/main/SubtitleTimeline.tsx
+++ b/src/main/SubtitleTimeline.tsx
@@ -132,8 +132,15 @@ const SubtitleTimeline: React.FC = () => {
     }
   };
 
+  const subtitleTimelineStyle = css({
+    position: "relative",
+    width: "100%",
+    height: "250px",
+    paddingBottom: "15px",
+  });
+
   return (
-    <div css={{ position: "relative", width: "100%", height: "250px" }}>
+    <div css={subtitleTimelineStyle}>
       {/* "Scrubber". Sits smack dab in the middle and does not move */}
       <div
         css={{


### PR DESCRIPTION
Fixes #931.

If the browser window was small enough to make scrollbars appear, the scrollbars could overlap the navigation element at the bottom of the subtitle editor, making it hardly usable. This fixes that by adding some padding.