### PR TITLE
Fix vertical scrolling in chapter view

### DIFF
--- a/src/main/Chapter.tsx
+++ b/src/main/Chapter.tsx
@@ -183,14 +183,16 @@ const Chapter: React.FC = () => {
               setCurrentlyAtAndTriggerPreview={setCurrentlyAtAndTriggerPreview}
             />
           </div>
-          <Timeline
-            selectCurrentlyAt={selectCurrentlyAt}
-            selectIsPlaying={selectIsPlaying}
-            setClickTriggered={setClickTriggered}
-            setCurrentlyAt={setCurrentlyAt}
-            setIsPlaying={setIsPlaying}
-            isChapters={true}
-          />
+          <div>
+            <Timeline
+              selectCurrentlyAt={selectCurrentlyAt}
+              selectIsPlaying={selectIsPlaying}
+              setClickTriggered={setClickTriggered}
+              setCurrentlyAt={setCurrentlyAt}
+              setIsPlaying={setIsPlaying}
+              isChapters={true}
+            />
+          </div>
           <CuttingActions
             add={cut}
             deleteByMerge={deleteByMerge}


### PR DESCRIPTION
Fix #1676

Adds a wrapper around the timeline in the chapter view. This should keep the timeline from shrinking when the vertical page size decreases, and make a scrollbar show up instead.

<img width="1768" height="922" alt="Bildschirmfoto vom 2026-02-04 15-13-47" src="https://github.com/user-attachments/assets/f18dcb48-646b-45b4-9cdc-7eb2f4e54df3" />
