### PR TITLE
Fix focus loss caused by sliders affecting keyboard shortcuts (follow-up to #1650)

### DIFF
--- a/src/globalKeys.ts
+++ b/src/globalKeys.ts
@@ -48,97 +48,161 @@ export interface IKeyGroup {
 export interface IKey {
   name: string;
   key: string;
+  options: object,
   splitKey?: string;
 }
+
+const hotkeysDefaultOptions: object = {
+  preventDefault: true,
+  enableOnFormTags: ["slider"],
+};
+
+export const subtitleListHotkeysDefaultOptions: object = {
+  preventDefault: true,
+  enableOnFormTags: ["input", "select", "textarea", "slider"],
+};
+
+const cuttingZoomInSplitKey = ";";
 
 export const KEYMAP: IKeyMap = {
   videoPlayer: {
     play: {
       name: "keyboardControls.videoPlayButton",
       key: "Shift+Alt+Space, Space",
+      options: {
+        ...hotkeysDefaultOptions,
+      },
     },
     previous: {
       name: "video.previousButton",
       key: "Shift+Alt+Left",
+      options: {
+        ...hotkeysDefaultOptions,
+      },
     },
     next: {
       name: "video.nextButton",
       key: "Shift+Alt+Right",
+      options: {
+        ...hotkeysDefaultOptions,
+      },
     },
     preview: {
       name: "video.previewButton",
       key: "Shift+Alt+p",
+      options: {
+        ...hotkeysDefaultOptions,
+      },
     },
   },
   cutting: {
     cut: {
       name: "cuttingActions.cut-button",
       key: "Shift+Alt+c",
+      options: {
+        ...hotkeysDefaultOptions,
+      },
     },
     delete: {
       name: "cuttingActions.delete-button",
       key: "Shift+Alt+d",
+      options: {
+        ...hotkeysDefaultOptions,
+      },
     },
     mergeLeft: {
       name: "cuttingActions.mergeLeft-button",
       key: "Shift+Alt+n",
+      options: {
+        ...hotkeysDefaultOptions,
+      },
     },
     mergeRight: {
       name: "cuttingActions.mergeRight-button",
       key: "Shift+Alt+m",
+      options: {
+        ...hotkeysDefaultOptions,
+      },
     },
     zoomIn: {
       name: "cuttingActions.zoomIn",
       key: "Shift;Alt;r, +",
-      splitKey: ";",
+      splitKey: cuttingZoomInSplitKey,
+      options: {
+        ...hotkeysDefaultOptions,
+        splitKey: cuttingZoomInSplitKey,
+        useKey: true,
+      },
     },
     zoomOut: {
       name: "cuttingActions.zoomOut",
       key: "Shift+Alt+e, -",
+      options: {
+        ...hotkeysDefaultOptions,
+        useKey: true,
+      },
     },
   },
   timeline: {
     left: {
       name: "keyboardControls.scrubberLeft",
       key: "Shift+Alt+j , Left",
+      options: {
+        preventDefault: true,
+      },
     },
     right: {
       name: "keyboardControls.scrubberRight",
       key: "Shift+Alt+l, Right",
+      options: {
+        preventDefault: true,
+      },
     },
     increase: {
       name: "keyboardControls.scrubberIncrease",
       key: "Shift+Alt+i, Up",
+      options: {
+        preventDefault: true,
+      },
     },
     decrease: {
       name: "keyboardControls.scrubberDecrease",
       key: "Shift+Alt+k, Down",
+      options: {
+        preventDefault: true,
+      },
     },
   },
   subtitleList: {
     addAbove: {
       name: "subtitleList.addSegmentAbove",
       key: "Shift+Alt+q",
+      options: {},
     },
     addBelow: {
       name: "subtitleList.addSegmentBelow",
       key: "Shift+Alt+a",
+      options: {},
     },
     jumpAbove: {
       name: "subtitleList.jumpToSegmentAbove",
       key: "Shift+Alt+w",
+      options: {},
     },
     jumpBelow: {
       name: "subtitleList.jumpToSegmentBelow",
       key: "Shift+Alt+s",
+      options: {},
     },
     delete: {
       name: "subtitleList.deleteSegment",
       key: "Shift+Alt+d",
+      options: {},
     },
     addCue: {
       name: "subtitleList.addCue",
       key: "Shift+Alt+e",
+      options: {},
     },
   },
 };

--- a/src/main/CuttingActions.tsx
+++ b/src/main/CuttingActions.tsx
@@ -94,37 +94,37 @@ const CuttingActions: React.FC<{
   useHotkeys(
     KEYMAP.cutting.cut.key,
     () => dispatchAction(cut),
-    { preventDefault: true },
+    KEYMAP.cutting.cut.options,
     [cut],
   );
   useHotkeys(
     KEYMAP.cutting.delete.key,
     () => dispatchAction(markAsDeletedOrAlive),
-    { preventDefault: true },
+    KEYMAP.cutting.delete.options,
     [markAsDeletedOrAlive],
   );
   useHotkeys(
     KEYMAP.cutting.mergeLeft.key,
     () => dispatchAction(mergeLeft),
-    { preventDefault: true },
+    KEYMAP.cutting.mergeLeft.options,
     [mergeLeft],
   );
   useHotkeys(
     KEYMAP.cutting.mergeRight.key,
     () => dispatchAction(mergeRight),
-    { preventDefault: true },
+    KEYMAP.cutting.mergeRight.options,
     [mergeRight],
   );
   useHotkeys(
     KEYMAP.cutting.zoomIn.key,
     () => dispatchAction(timelineZoomIn),
-    { preventDefault: true, splitKey: KEYMAP.cutting.zoomIn.splitKey, useKey: true },
+    KEYMAP.cutting.zoomIn.options,
     [timelineZoomIn],
   );
   useHotkeys(
     KEYMAP.cutting.zoomOut.key,
     () => dispatchAction(timelineZoomOut),
-    { preventDefault: true, useKey: true },
+    KEYMAP.cutting.zoomOut.options,
     [timelineZoomOut],
   );
 
@@ -446,6 +446,13 @@ const ZoomSlider : React.FC<ZoomSliderInterface> = ({
           onChange={zoomSliderOnChange}
           aria-label={ariaLabelText}
           valueLabelDisplay="off"
+          slotProps={
+            {
+              input: {
+                role: "slider",
+              },
+            }
+          }
         />
       </div>
     </ThemedTooltip>

--- a/src/main/SubtitleListEditor.tsx
+++ b/src/main/SubtitleListEditor.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from "react-i18next";
 import { shallowEqual } from "react-redux";
 import { RootState, useAppDispatch, useAppSelector } from "../redux/store";
 import { basicButtonStyle } from "../cssStyles";
-import { KEYMAP } from "../globalKeys";
+import { KEYMAP, subtitleListHotkeysDefaultOptions } from "../globalKeys";
 import { SubtitleCue, SubtitlesInEditor } from "../types";
 import { convertMsToReadableString } from "../util/utilityFunctions";
 import { ListChildComponentProps, VariableSizeList } from "react-window";
@@ -443,7 +443,7 @@ const SubtitleListSegment : React.FC<{
         deleteCue();
         break;
     }
-  }, { enableOnFormTags: ["input", "select", "textarea"], preventDefault: true }, [identifier, cue, props.index]);
+  }, subtitleListHotkeysDefaultOptions, [identifier, cue, props.index]);
 
   const hotkeyDivRef = hotkeyRef as React.RefObject<HTMLDivElement>;
 

--- a/src/main/SubtitleTimeline.tsx
+++ b/src/main/SubtitleTimeline.tsx
@@ -91,27 +91,32 @@ const SubtitleTimeline: React.FC = () => {
   useHotkeys(
     KEYMAP.timeline.left.key,
     () => dispatch(setCurrentlyAt(Math.max(currentlyAt - keyboardJumpDelta, 0))),
-    {}, [currentlyAt, keyboardJumpDelta],
+    KEYMAP.timeline.left.options,
+    [currentlyAt, keyboardJumpDelta],
   );
   useHotkeys(
     KEYMAP.timeline.right.key,
     () => dispatch(setCurrentlyAt(Math.min(currentlyAt + keyboardJumpDelta, duration))),
-    {}, [currentlyAt, keyboardJumpDelta, duration],
+    KEYMAP.timeline.right.options,
+    [currentlyAt, keyboardJumpDelta, duration],
   );
   useHotkeys(
     KEYMAP.timeline.increase.key,
     () => setKeyboardJumpDelta(keyboardJumpDelta => Math.min(keyboardJumpDelta * 10, 1000000)),
-    {}, [keyboardJumpDelta],
+    KEYMAP.timeline.increase.options,
+    [keyboardJumpDelta],
   );
   useHotkeys(
     KEYMAP.timeline.decrease.key,
     () => setKeyboardJumpDelta(keyboardJumpDelta => Math.max(keyboardJumpDelta / 10, 1)),
-    {}, [keyboardJumpDelta],
+    KEYMAP.timeline.decrease.options,
+    [keyboardJumpDelta],
   );
   useHotkeys(
     KEYMAP.subtitleList.addCue.key,
     () => addCue(currentlyAt),
-    {}, [currentlyAt],
+    KEYMAP.subtitleList.addCue.options,
+    [currentlyAt],
   );
 
   // Callback for the scroll container

--- a/src/main/Timeline.tsx
+++ b/src/main/Timeline.tsx
@@ -283,25 +283,25 @@ export const Scrubber = React.forwardRef<HTMLDivElement, ScrubberProps>((props, 
   useHotkeys(
     KEYMAP.timeline.left.key,
     () => dispatch(setCurrentlyAt(Math.max(currentlyAt - keyboardJumpDelta, 0))),
-    {},
+    KEYMAP.timeline.left.options,
     [currentlyAt, keyboardJumpDelta],
   );
   useHotkeys(
     KEYMAP.timeline.right.key,
     () => dispatch(setCurrentlyAt(Math.min(currentlyAt + keyboardJumpDelta, duration))),
-    {},
+    KEYMAP.timeline.right.options,
     [currentlyAt, keyboardJumpDelta, duration],
   );
   useHotkeys(
     KEYMAP.timeline.increase.key,
     () => setKeyboardJumpDelta(keyboardJumpDelta => Math.min(keyboardJumpDelta * 10, 1000000)),
-    { preventDefault: true },
+    KEYMAP.timeline.increase.options,
     [keyboardJumpDelta],
   );
   useHotkeys(
     KEYMAP.timeline.decrease.key,
     () => setKeyboardJumpDelta(keyboardJumpDelta => Math.max(keyboardJumpDelta / 10, 1)),
-    { preventDefault: true },
+    KEYMAP.timeline.decrease.options,
     [keyboardJumpDelta],
   );
 

--- a/src/main/VideoControls.tsx
+++ b/src/main/VideoControls.tsx
@@ -138,7 +138,7 @@ const PreviewMode: React.FC<{
   useHotkeys(
     KEYMAP.videoPlayer.preview.key,
     () => switchPlayPreview(undefined),
-    { preventDefault: true },
+    KEYMAP.videoPlayer.preview.options,
     [isPlayPreview],
   );
 
@@ -213,7 +213,12 @@ const PlayButton: React.FC<{
   };
 
   // Maps functions to hotkeys
-  useHotkeys(KEYMAP.videoPlayer.play.key, () => switchIsPlaying(), { preventDefault: true }, [isPlaying]);
+  useHotkeys(
+    KEYMAP.videoPlayer.play.key,
+    () => switchIsPlaying(),
+    KEYMAP.videoPlayer.play.options,
+    [isPlaying],
+  );
 
   const playButtonStyle = css({
     justifySelf: "center",
@@ -265,7 +270,11 @@ const PreviousButton: React.FC<{
     dispatch(jumpToPreviousSegment());
   };
 
-  useHotkeys(KEYMAP.videoPlayer.previous.key, () => jumpToPrevious(), { preventDefault: true });
+  useHotkeys(
+    KEYMAP.videoPlayer.previous.key,
+    () => jumpToPrevious(),
+    KEYMAP.videoPlayer.previous.options,
+  );
 
   const previousIconStyle = css({
     fontSize: 24,
@@ -307,7 +316,11 @@ const NextButton: React.FC<{
     dispatch(jumpToNextSegment());
   };
 
-  useHotkeys(KEYMAP.videoPlayer.next.key, () => jumpToNext(), { preventDefault: true });
+  useHotkeys(
+    KEYMAP.videoPlayer.next.key,
+    () => jumpToNext(),
+    KEYMAP.videoPlayer.next.options,
+  );
 
   const nextIconStyle = css({
     fontSize: 24,
@@ -474,6 +487,13 @@ const VolumeSlider: React.FC<{
           onChange={volumeOnChange}
           aria-label={t("video.volume-tooltip", { current: Math.trunc(volume * 100) })}
           valueLabelDisplay="off"
+          slotProps={
+            {
+              input: {
+                role: "slider",
+              },
+            }
+          }
         />
       </ThemedTooltip>
     </div>


### PR DESCRIPTION
This PR is a follow-up/fix for the new keyboard shortcuts introduced in #1650.

The issue occurred because the sliders (zoom and volume) were taking focus during interaction and not returning it afterward to the main element. As a result, keyboard shortcuts stopped working once users adjusted those sliders.

**Solution**

This PR introduces a `MainFocusContext` that allows components to restore focus back to the main workspace after slider interaction completes.

Specifically:

* A focus context is added and provided at the main content level
* Components using sliders consume this context
* Slider `onChangeCommitted` events trigger restoring focus to the main workspace
* Keyboard shortcuts remain functional after slider usage
* The `MainFocusContext` can be used also in other places later on!

**Result**

After adjusting zoom or volume sliders:

* focus returns to the main element automatically
* keyboard shortcuts continue working as expected
* behavior stays consistent with the intended shortcut workflow


## UPDATE

This PR had a revert on the above mentioned solution and now got newer changes: https://github.com/opencast/editor/pull/1694#issuecomment-4223842080
