### PR TITLE
Ensure node version matches parent pom

### DIFF
--- a/.github/workflows/deploy-main-branches.yml
+++ b/.github/workflows/deploy-main-branches.yml
@@ -55,7 +55,9 @@ jobs:
       - name: Ensure our node version matches the main repo's version
         run: |
           [[ "$(curl -s https://raw.githubusercontent.com/opencast/opencast/refs/heads/${{ github.ref_name }}/pom.xml | \
-              grep node.version | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)" == "$NODE_VERSION" ]] && exit 0 || exit 1
+              grep node.version | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)" == "$NODE_VERSION" ]] \
+          && exit 0 \
+          || (echo "Node version does not match"; exit 1)
 
       - name: Run npm ci
         run: npm ci

--- a/.github/workflows/deploy-main-branches.yml
+++ b/.github/workflows/deploy-main-branches.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
+env:
+  NODE_VERSION: 24
+
 jobs:
   detect-repo-owner:
     name: Detect branch and appropriate server
@@ -47,7 +50,12 @@ jobs:
       - name: Get Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Ensure our node version matches the main repo's version
+        run: |
+          [[ "$(curl -s https://raw.githubusercontent.com/opencast/opencast/refs/heads/${{ github.ref_name }}/pom.xml | \
+              grep node.version | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)" == "$NODE_VERSION" ]] && exit 0 || exit 1
 
       - name: Run npm ci
         run: npm ci

--- a/.github/workflows/pr-deploy-test-branch.yml
+++ b/.github/workflows/pr-deploy-test-branch.yml
@@ -10,6 +10,9 @@ concurrency:
   group: pull-request-page
   cancel-in-progress: false
 
+env:
+  NODE_VERSION: 24
+
 jobs:
   detect-repo-owner:
     if: github.repository_owner == 'opencast'
@@ -53,7 +56,12 @@ jobs:
       - name: Get Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Ensure our node version matches the main repo's version
+        run: |
+          [[ "$(curl -s https://raw.githubusercontent.com/opencast/opencast/refs/heads/${{ github.ref_name }}/pom.xml | \
+              grep node.version | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)" == "$NODE_VERSION" ]] && exit 0 || exit 1
 
       - name: Run npm ci
         run: npm ci

--- a/.github/workflows/pr-deploy-test-branch.yml
+++ b/.github/workflows/pr-deploy-test-branch.yml
@@ -60,8 +60,10 @@ jobs:
 
       - name: Ensure our node version matches the main repo's version
         run: |
-          [[ "$(curl -s https://raw.githubusercontent.com/opencast/opencast/refs/heads/${{ github.ref_name }}/pom.xml | \
-              grep node.version | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)" == "$NODE_VERSION" ]] && exit 0 || exit 1
+          [[ "$(curl -s https://raw.githubusercontent.com/opencast/opencast/refs/heads/${{ github.base_ref }}/pom.xml | \
+              grep node.version | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)" == "$NODE_VERSION" ]] \
+          && exit 0 \
+          || (echo "Node version does not match"; exit 1)
 
       - name: Run npm ci
         run: npm ci

--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -9,6 +9,9 @@ on:
       - develop
       - r/*
 
+env:
+  NODE_VERSION: 24
+
 jobs:
   check-npm-test:
     runs-on: ubuntu-latest
@@ -20,7 +23,12 @@ jobs:
       - name: Get Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+           node-version: ${{ env.NODE_VERSION }}
+
+      - name: Ensure our node version matches the main repo's version
+        run: |
+          [[ "$(curl -s https://raw.githubusercontent.com/opencast/opencast/refs/heads/${{ github.ref_name }}/pom.xml | \
+              grep node.version | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)" == "$NODE_VERSION" ]] && exit 0 || exit 1
 
       - name: Run npm ci
         run: npm ci

--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -26,9 +26,19 @@ jobs:
            node-version: ${{ env.NODE_VERSION }}
 
       - name: Ensure our node version matches the main repo's version
+        if: github.event_name == 'pull_request'
+        run: |
+          [[ "$(curl -s https://raw.githubusercontent.com/opencast/opencast/refs/heads/${{ github.base_ref }}/pom.xml | \
+              grep node.version | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)" == "$NODE_VERSION" ]] \
+          && exit 0 \
+          || (echo "Node version does not match"; exit 1)
+      - name: Ensure our node version matches the main repo's version
+        if: github.event_name == 'push'
         run: |
           [[ "$(curl -s https://raw.githubusercontent.com/opencast/opencast/refs/heads/${{ github.ref_name }}/pom.xml | \
-              grep node.version | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)" == "$NODE_VERSION" ]] && exit 0 || exit 1
+              grep node.version | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)" == "$NODE_VERSION" ]] \
+          && exit 0 \
+          || (echo "Node version does not match"; exit 1)
 
       - name: Run npm ci
         run: npm ci

--- a/.github/workflows/pr-test-playwright.yml
+++ b/.github/workflows/pr-test-playwright.yml
@@ -27,9 +27,19 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
     - name: Ensure our node version matches the main repo's version
+      if: github.event_name == 'pull_request'
+      run: |
+        [[ "$(curl -s https://raw.githubusercontent.com/opencast/opencast/refs/heads/${{ github.base_ref }}/pom.xml | \
+            grep node.version | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)" == "$NODE_VERSION" ]] \
+        && exit 0 \
+        || (echo "Node version does not match"; exit 1)
+    - name: Ensure our node version matches the main repo's version
+      if: github.event_name == 'push'
       run: |
         [[ "$(curl -s https://raw.githubusercontent.com/opencast/opencast/refs/heads/${{ github.ref_name }}/pom.xml | \
-            grep node.version | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)" == "$NODE_VERSION" ]] && exit 0 || exit 1
+            grep node.version | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)" == "$NODE_VERSION" ]] \
+        && exit 0 \
+        || (echo "Node version does not match"; exit 1)
 
     - name: Install dependencies
       run: npm ci

--- a/.github/workflows/pr-test-playwright.yml
+++ b/.github/workflows/pr-test-playwright.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - develop
       - r/*
+
+env:
+  NODE_VERSION: 24
+
 jobs:
   test:
 
@@ -20,7 +24,12 @@ jobs:
     - name: Install Node Dependency
       uses: actions/setup-node@v6
       with:
-        node-version: 20
+          node-version: ${{ env.NODE_VERSION }}
+
+    - name: Ensure our node version matches the main repo's version
+      run: |
+        [[ "$(curl -s https://raw.githubusercontent.com/opencast/opencast/refs/heads/${{ github.ref_name }}/pom.xml | \
+            grep node.version | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)" == "$NODE_VERSION" ]] && exit 0 || exit 1
 
     - name: Install dependencies
       run: npm ci

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,6 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <nodejs.version>v20.10.0</nodejs.version>
   </properties>
   <profiles>
     <profile>
@@ -101,7 +100,7 @@
             <groupId>com.github.eirslett</groupId>
             <artifactId>frontend-maven-plugin</artifactId>
             <configuration>
-              <nodeVersion>${nodejs.version}</nodeVersion>
+              <nodeVersion>${node.version}</nodeVersion>
               <installDirectory>target</installDirectory>
               <environmentVariables>
                 <PUBLIC_URL>/editor-ui</PUBLIC_URL>


### PR DESCRIPTION
This PR checks to see that *our* node vesrion matches hte upstream parent's pom's version.

This has hte side effect of updating the current versino of node in use, especially once https://github.com/opencast/opencast/pull/7636 is merged.
