### PR TITLE
Properly label GHA dependeabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    labels:
+      - type:infrastructure
 
   # Javascript
   - package-ecosystem: npm


### PR DESCRIPTION
The current dependabot config creates PRs without appropriate labels.  This fixes that.
