### PR TITLE
Improve npm checks

### DIFF
--- a/.github/workflows/deploy-main-branches.yml
+++ b/.github/workflows/deploy-main-branches.yml
@@ -52,12 +52,14 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Ensure our node version matches the main repo's version
+      - name: Ensure our node version matches the main repo's version for push events
+        if: github.event_name == 'push' && (startsWith("r/", github.ref_name) || "develop" == github.ref_name)
         run: |
-          [[ "$(curl -s https://raw.githubusercontent.com/opencast/opencast/refs/heads/${{ github.ref_name }}/pom.xml | \
-              grep node.version | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)" == "$NODE_VERSION" ]] \
+          curl -s https://raw.githubusercontent.com/opencast/opencast/refs/heads/${{ github.ref_name }}/pom.xml -o pom.xml
+          export FOUND_VERSION="$(grep node.version pom.xml | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)"
+          [[ "$FOUND_VERSION" == "$NODE_VERSION" ]] \
           && exit 0 \
-          || (echo "Node version does not match"; exit 1)
+          || (echo "Node version does not match.  Expected $NODE_VERSION, found $FOUND_VERSION"; exit 1)
 
       - name: Run npm ci
         run: npm ci

--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -25,20 +25,22 @@ jobs:
         with:
            node-version: ${{ env.NODE_VERSION }}
 
-      - name: Ensure our node version matches the main repo's version
+      - name: Ensure our node version matches the main repo's version for pull requests
         if: github.event_name == 'pull_request'
         run: |
-          [[ "$(curl -s https://raw.githubusercontent.com/opencast/opencast/refs/heads/${{ github.base_ref }}/pom.xml | \
-              grep node.version | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)" == "$NODE_VERSION" ]] \
+          curl -s https://raw.githubusercontent.com/opencast/opencast/refs/heads/${{ github.base_ref }}/pom.xml -o pom.xml
+          export FOUND_VERSION="$(grep node.version pom.xml | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)"
+          [[ "$FOUND_VERSION" == "$NODE_VERSION" ]] \
           && exit 0 \
-          || (echo "Node version does not match"; exit 1)
-      - name: Ensure our node version matches the main repo's version
-        if: github.event_name == 'push'
+          || (echo "Node version does not match.  Expected $NODE_VERSION, found $FOUND_VERSION"; exit 1)
+      - name: Ensure our node version matches the main repo's version for push events
+        if: github.event_name == 'push' && (startsWith("r/", github.ref_name) || "develop" == github.ref_name)
         run: |
-          [[ "$(curl -s https://raw.githubusercontent.com/opencast/opencast/refs/heads/${{ github.ref_name }}/pom.xml | \
-              grep node.version | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)" == "$NODE_VERSION" ]] \
+          curl -s https://raw.githubusercontent.com/opencast/opencast/refs/heads/${{ github.ref_name }}/pom.xml -o pom.xml
+          export FOUND_VERSION="$(grep node.version pom.xml | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)"
+          [[ "$FOUND_VERSION" == "$NODE_VERSION" ]] \
           && exit 0 \
-          || (echo "Node version does not match"; exit 1)
+          || (echo "Node version does not match.  Expected $NODE_VERSION, found $FOUND_VERSION"; exit 1)
 
       - name: Run npm ci
         run: npm ci

--- a/.github/workflows/pr-test-playwright.yml
+++ b/.github/workflows/pr-test-playwright.yml
@@ -26,20 +26,22 @@ jobs:
       with:
           node-version: ${{ env.NODE_VERSION }}
 
-    - name: Ensure our node version matches the main repo's version
-      if: github.event_name == 'pull_request'
-      run: |
-        [[ "$(curl -s https://raw.githubusercontent.com/opencast/opencast/refs/heads/${{ github.base_ref }}/pom.xml | \
-            grep node.version | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)" == "$NODE_VERSION" ]] \
-        && exit 0 \
-        || (echo "Node version does not match"; exit 1)
-    - name: Ensure our node version matches the main repo's version
-      if: github.event_name == 'push'
-      run: |
-        [[ "$(curl -s https://raw.githubusercontent.com/opencast/opencast/refs/heads/${{ github.ref_name }}/pom.xml | \
-            grep node.version | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)" == "$NODE_VERSION" ]] \
-        && exit 0 \
-        || (echo "Node version does not match"; exit 1)
+      - name: Ensure our node version matches the main repo's version for pull requests
+        if: github.event_name == 'pull_request'
+        run: |
+          curl -s https://raw.githubusercontent.com/opencast/opencast/refs/heads/${{ github.base_ref }}/pom.xml -o pom.xml
+          export FOUND_VERSION="$(grep node.version pom.xml | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)"
+          [[ "$FOUND_VERSION" == "$NODE_VERSION" ]] \
+          && exit 0 \
+          || (echo "Node version does not match.  Expected $NODE_VERSION, found $FOUND_VERSION"; exit 1)
+      - name: Ensure our node version matches the main repo's version for push events
+        if: github.event_name == 'push' && (startsWith("r/", github.ref_name) || "develop" == github.ref_name)
+        run: |
+          curl -s https://raw.githubusercontent.com/opencast/opencast/refs/heads/${{ github.ref_name }}/pom.xml -o pom.xml
+          export FOUND_VERSION="$(grep node.version pom.xml | grep -Eo 'v[0-9.]+' | cut -f 1 -d '.' | cut -c 2-)"
+          [[ "$FOUND_VERSION" == "$NODE_VERSION" ]] \
+          && exit 0 \
+          || (echo "Node version does not match.  Expected $NODE_VERSION, found $FOUND_VERSION"; exit 1)
 
     - name: Install dependencies
       run: npm ci


### PR DESCRIPTION
This PR:

- Improves the logging in cases where the PR/branch's node version does not match the upstream version expected
- Only run the checks on PRs, or pushes to branches matching r/, or develop. Otherwise if you push to dependabot/my_dep, we see a failure because that branch doesn't exist in opencast/opencast